### PR TITLE
게시글 작성 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,16 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // jasypt
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.5'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation:3.3.1'
+
+    // flyway
     implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.flywaydb:flyway-core'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
     // flyway
     implementation 'org.flywaydb:flyway-mysql'
     implementation 'org.flywaydb:flyway-core'
+
+    // S3
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.690'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -1,0 +1,31 @@
+package com.carrot.carrotmarketclonecoding.board.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_SUCCESS;
+
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.service.BoardService;
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class BoardController {
+    private final BoardService boardService;
+
+    @PostMapping("/board/register")
+    public ResponseEntity<?> register(@RequestBody @Valid BoardRegisterRequestDto registerRequestDto) {
+        // TODO memberId -> JWT.getMemberId()
+        Long memberId = 1L;
+
+        boardService.register(registerRequestDto, memberId);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ResponseResult.success(HttpStatus.CREATED, BOARD_REGISTER_SUCCESS.getMessage(), null));
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -9,8 +9,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,7 +19,7 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping("/board/register")
-    public ResponseEntity<?> register(@RequestBody @Valid BoardRegisterRequestDto registerRequestDto) {
+    public ResponseEntity<?> register(@ModelAttribute @Valid BoardRegisterRequestDto registerRequestDto) {
         // TODO memberId -> JWT.getMemberId()
         Long memberId = 1L;
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
@@ -1,0 +1,76 @@
+package com.carrot.carrotmarketclonecoding.board.domain;
+
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "boards")
+public class Board extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+
+    @Enumerated(EnumType.STRING)
+    private Method method;
+
+    private int price;
+    private Boolean suggest;
+    private String description;
+    private String place;
+
+    @Builder.Default
+    private int visit = 0;
+
+    @Builder.Default
+    private Boolean hide = false;   // 수정만 가능
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private Status status = Status.SELL;  // 수정만 가능
+
+    private Boolean tmp;
+
+    public static Board createBoard(BoardRegisterRequestDto boardInputRequestDto, Member member, Category category) {
+        return Board.builder()
+                .title(boardInputRequestDto.getTitle())
+                .member(member)
+                .category(category)
+                .method(boardInputRequestDto.getMethod())
+                .price(boardInputRequestDto.getPrice())
+                .suggest(boardInputRequestDto.getSuggest())
+                .description(boardInputRequestDto.getDescription())
+                .place(boardInputRequestDto.getPlace())
+                .tmp(boardInputRequestDto.getTmp())
+                .build();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/BoardPicture.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/BoardPicture.java
@@ -1,0 +1,29 @@
+package com.carrot.carrotmarketclonecoding.board.domain;
+
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Entity
+@Table(name = "board_pictures")
+public class BoardPicture extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+
+    private String pictureUrl;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Category.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Category.java
@@ -1,0 +1,25 @@
+package com.carrot.carrotmarketclonecoding.board.domain;
+
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Entity
+@Table(name = "categories")
+public class Category extends BaseEntity {
+    @Id
+    private Long id;
+
+    private String name;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/enums/Method.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/enums/Method.java
@@ -1,0 +1,16 @@
+package com.carrot.carrotmarketclonecoding.board.domain.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.util.Arrays;
+
+public enum Method {
+    SELL, SHARE;
+
+    @JsonCreator
+    public static Method methodValidate(String val) {
+        return Arrays.stream(values())
+                .filter(type -> type.name().equals(val))
+                .findAny()
+                .orElse(null);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/enums/Status.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/enums/Status.java
@@ -1,0 +1,5 @@
+package com.carrot.carrotmarketclonecoding.board.domain.enums;
+
+public enum Status {
+    SELL, SOLD
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -1,5 +1,7 @@
 package com.carrot.carrotmarketclonecoding.board.dto;
 
+import static com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE.*;
+
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.common.exception.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
@@ -19,26 +21,25 @@ public class BoardRequestDto {
     public static class BoardRegisterRequestDto {
         private MultipartFile[] pictures;
 
-        @NotEmpty(message = "제목은 필수 입력사항입니다!")
+        @NotEmpty(message = TITLE_NOT_VALID)
         private String title;
 
-        @NotNull(message = "카테고리는 필수 입력사항입니다!")
+        @NotNull(message = CATEGORY_NOT_VALID)
         private Long categoryId;
 
-//        @NotNull(message = "거래방식은 필수 입력사항입니다!")
         @ValidEnum(enumClass = Method.class)
         private Method method;
 
-        @NotNull(message = "가격은 필수 입력사항입니다!")
+        @NotNull(message = PRICE_NOT_VALID)
         private Integer price;
 
-        @NotNull(message = "거래제안받기여부는 필수 입력사항입니다!")
+        @NotNull(message = SUGGEST_NOT_VALID)
         private Boolean suggest;
 
-        @Size(max = 300, message = "상품 설명은 300글자 이내여야 합니다!")
+        @Size(max = 300, message = DESCRIPTION_NOT_VALID)
         private String description;
 
-        @NotEmpty(message = "거래희망장소는 필수 입력사항입니다!")
+        @NotEmpty(message = PLACE_NOT_VALID)
         private String place;
 
         private Boolean tmp;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -1,0 +1,46 @@
+package com.carrot.carrotmarketclonecoding.board.dto;
+
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.common.exception.ValidEnum;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+public class BoardRequestDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardRegisterRequestDto {
+        private MultipartFile[] pictures;
+
+        @NotEmpty(message = "제목은 필수 입력사항입니다!")
+        private String title;
+
+        @NotNull(message = "카테고리는 필수 입력사항입니다!")
+        private Long categoryId;
+
+//        @NotNull(message = "거래방식은 필수 입력사항입니다!")
+        @ValidEnum(enumClass = Method.class)
+        private Method method;
+
+        @NotNull(message = "가격은 필수 입력사항입니다!")
+        private Integer price;
+
+        @NotNull(message = "거래제안받기여부는 필수 입력사항입니다!")
+        private Boolean suggest;
+
+        @Size(max = 300, message = "상품 설명은 300글자 이내여야 합니다!")
+        private String description;
+
+        @NotEmpty(message = "거래희망장소는 필수 입력사항입니다!")
+        private String place;
+
+        private Boolean tmp;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -3,7 +3,7 @@ package com.carrot.carrotmarketclonecoding.board.dto;
 import static com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE.*;
 
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
-import com.carrot.carrotmarketclonecoding.common.exception.ValidEnum;
+import com.carrot.carrotmarketclonecoding.common.validation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/validation/BoardRegisterValidationMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/validation/BoardRegisterValidationMessage.java
@@ -1,0 +1,26 @@
+package com.carrot.carrotmarketclonecoding.board.dto.validation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BoardRegisterValidationMessage {
+    TITLE_NOT_VALID(MESSAGE.TITLE_NOT_VALID),
+    CATEGORY_NOT_VALID(MESSAGE.CATEGORY_NOT_VALID),
+    PRICE_NOT_VALID(MESSAGE.PRICE_NOT_VALID),
+    SUGGEST_NOT_VALID(MESSAGE.SUGGEST_NOT_VALID),
+    DESCRIPTION_NOT_VALID(MESSAGE.DESCRIPTION_NOT_VALID),
+    PLACE_NOT_VALID(MESSAGE.PLACE_NOT_VALID);
+
+    private final String message;
+
+    public static class MESSAGE {
+        public static final String TITLE_NOT_VALID = "제목은 필수 입력사항입니다!";
+        public static final String CATEGORY_NOT_VALID = "카테고리는 필수 입력사항입니다!";
+        public static final String PRICE_NOT_VALID = "가격은 필수 입력사항입니다!";
+        public static final String SUGGEST_NOT_VALID = "거래제안받기여부는 필수 입력사항입니다!";
+        public static final String DESCRIPTION_NOT_VALID = "상품 설명은 300글자 이내여야 합니다!";
+        public static final String PLACE_NOT_VALID = "거래희망장소는 필수 입력사항입니다!";
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardPictureRepository extends JpaRepository<BoardPicture, Long> {
+
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepository.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardRepository extends JpaRepository<Board, Long> {
+
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/CategoryRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -1,0 +1,7 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+
+public interface BoardService {
+    Long register(BoardRegisterRequestDto inputRequestDto, Long memberId);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -1,0 +1,39 @@
+package com.carrot.carrotmarketclonecoding.board.service.impl;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.Category;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
+import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
+import com.carrot.carrotmarketclonecoding.board.service.BoardService;
+import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardServiceImpl implements BoardService {
+    private final BoardRepository boardRepository;
+    private final MemberRepository memberRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Override
+    public Long register(BoardRegisterRequestDto registerRequestDto, Long memberId) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        Category category = categoryRepository.findById(registerRequestDto.getCategoryId()).orElseThrow(CategoryNotFoundException::new);
+
+        if (registerRequestDto.getMethod() == Method.SHARE) {
+            registerRequestDto.setPrice(0);
+        }
+
+        Board board = boardRepository.save(Board.createBoard(registerRequestDto, member, category));
+
+        // TODO 첨부파일 저장
+
+        return board.getId();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -10,6 +10,7 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.file.service.impl.FileServiceImpl;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
@@ -29,30 +30,42 @@ public class BoardServiceImpl implements BoardService {
     private final BoardPictureRepository boardPictureRepository;
     private final FileServiceImpl fileService;
 
+    private final int FILE_LIMIT_COUNT = 10;
+
     @Override
     public Long register(BoardRegisterRequestDto registerRequestDto, Long memberId) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        Category category = categoryRepository.findById(registerRequestDto.getCategoryId()).orElseThrow(CategoryNotFoundException::new);
+        Category category = categoryRepository.findById(registerRequestDto.getCategoryId())
+                .orElseThrow(CategoryNotFoundException::new);
 
-        if (registerRequestDto.getMethod() == Method.SHARE) {
-            registerRequestDto.setPrice(0);
-        }
+        checkMethod(registerRequestDto);
 
         Board board = boardRepository.save(Board.createBoard(registerRequestDto, member, category));
 
+        validatePictures(registerRequestDto.getPictures());
+
         if (registerRequestDto.getPictures() != null && registerRequestDto.getPictures().length > 0) {
-            savePictures(registerRequestDto.getPictures(), board);
+            uploadPictures(registerRequestDto.getPictures(), board);
         }
 
         return board.getId();
     }
 
-    private void savePictures(MultipartFile[] pictures, Board board) {
+    private void checkMethod(BoardRegisterRequestDto registerRequestDto) {
+        if (registerRequestDto.getMethod() == Method.SHARE) {
+            registerRequestDto.setPrice(0);
+        }
+    }
+
+    private void validatePictures(MultipartFile[] pictures) {
+        if (pictures.length > FILE_LIMIT_COUNT) {
+            throw new FileUploadLimitException();
+        }
+    }
+
+    private void uploadPictures(MultipartFile[] pictures, Board board) {
         for (MultipartFile file : pictures) {
             String pictureUrl = fileService.uploadImage(file);
-
-            log.debug("pictureUrl: " + pictureUrl);
-
             boardPictureRepository.save(BoardPicture.builder()
                     .board(board)
                     .pictureUrl(pictureUrl)

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -1,25 +1,33 @@
 package com.carrot.carrotmarketclonecoding.board.service.impl;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
 import com.carrot.carrotmarketclonecoding.board.domain.Category;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.file.service.impl.FileServiceImpl;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BoardServiceImpl implements BoardService {
     private final BoardRepository boardRepository;
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final BoardPictureRepository boardPictureRepository;
+    private final FileServiceImpl fileService;
 
     @Override
     public Long register(BoardRegisterRequestDto registerRequestDto, Long memberId) {
@@ -32,8 +40,23 @@ public class BoardServiceImpl implements BoardService {
 
         Board board = boardRepository.save(Board.createBoard(registerRequestDto, member, category));
 
-        // TODO 첨부파일 저장
+        if (registerRequestDto.getPictures() != null && registerRequestDto.getPictures().length > 0) {
+            savePictures(registerRequestDto.getPictures(), board);
+        }
 
         return board.getId();
+    }
+
+    private void savePictures(MultipartFile[] pictures, Board board) {
+        for (MultipartFile file : pictures) {
+            String pictureUrl = fileService.uploadImage(file);
+
+            log.debug("pictureUrl: " + pictureUrl);
+
+            boardPictureRepository.save(BoardPicture.builder()
+                    .board(board)
+                    .pictureUrl(pictureUrl)
+                    .build());
+        }
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/BaseEntity.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/BaseEntity.java
@@ -1,0 +1,20 @@
+package com.carrot.carrotmarketclonecoding.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createDate;
+
+    @LastModifiedDate
+    private LocalDateTime updateDate;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CategoryNotFoundException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CATEGORY_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class CategoryNotFoundException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.NOT_FOUND;
+    }
+
+    @Override
+    public String getMessage() {
+        return CATEGORY_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CategoryNotFoundException.java
@@ -8,7 +8,7 @@ public class CategoryNotFoundException extends CustomException {
 
     @Override
     public HttpStatus getStatus() {
-        return HttpStatus.NOT_FOUND;
+        return HttpStatus.BAD_REQUEST;
     }
 
     @Override

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CustomException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/CustomException.java
@@ -1,0 +1,9 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+public abstract class CustomException extends RuntimeException {
+    abstract public HttpStatus getStatus();
+    abstract public String getMessage();
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/EnumValidator.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/EnumValidator.java
@@ -1,0 +1,28 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, Enum> {
+    private ValidEnum annotation;
+
+    @Override
+    public void initialize(ValidEnum constraintAnnotation) {
+        this.annotation = constraintAnnotation;
+    }
+
+    @Override
+    public boolean isValid(Enum value, ConstraintValidatorContext context) {
+        boolean result = false;
+        Object[] enumValues = this.annotation.enumClass().getEnumConstants();
+        if (enumValues != null) {
+            for (Object enumValue : enumValues) {
+                if (value == enumValue) {
+                    result = true;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileExtensionNotValidException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileExtensionNotValidException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FILE_EXTENSION_NOT_VALID;
+
+import org.springframework.http.HttpStatus;
+
+public class FileExtensionNotValidException extends CustomException{
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.UNSUPPORTED_MEDIA_TYPE;
+    }
+
+    @Override
+    public String getMessage() {
+        return FILE_EXTENSION_NOT_VALID.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileNotExistsException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileNotExistsException.java
@@ -1,0 +1,17 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FILE_NOT_EXISTS;
+
+import org.springframework.http.HttpStatus;
+
+public class FileNotExistsException extends CustomException {
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return FILE_NOT_EXISTS.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileUploadFailedException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileUploadFailedException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FILE_UPLOAD_FAILED;
+
+import org.springframework.http.HttpStatus;
+
+public class FileUploadFailedException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return FILE_UPLOAD_FAILED.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileUploadLimitException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/FileUploadLimitException.java
@@ -1,0 +1,17 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FILE_UPLOAD_LIMIT;
+
+import org.springframework.http.HttpStatus;
+
+public class FileUploadLimitException extends CustomException {
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return FILE_UPLOAD_LIMIT.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/MemberNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/MemberNotFoundException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberNotFoundException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+
+    @Override
+    public String getMessage() {
+        return MEMBER_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/ValidEnum.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/ValidEnum.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Constraint(validatedBy = EnumValidator.class)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidEnum {
+    String message() default "잘못된 입력입니다!";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+    Class<? extends java.lang.Enum<?>> enumClass();
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/handler/CustomExceptionHandler.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/handler/CustomExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.carrot.carrotmarketclonecoding.common.handler;
+
+import com.carrot.carrotmarketclonecoding.common.exception.CustomException;
+import com.carrot.carrotmarketclonecoding.common.response.FailedMessage;
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Component
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> customExceptionHandler(CustomException e) {
+        return ResponseEntity.status(e.getStatus()).body(ResponseResult.failed(e.getStatus(), e.getMessage(), null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected ResponseEntity<?> validationException(MethodArgumentNotValidException e) {
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        Map<String, String> map = new HashMap<>();
+        for (FieldError error: fieldErrors) {
+            String field = error.getField();
+            String message = error.getDefaultMessage();
+            map.put(field, message);
+        }
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ResponseResult.failed(HttpStatus.BAD_REQUEST, FailedMessage.INPUT_NOT_VALID.getMessage(), map));
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -1,0 +1,14 @@
+package com.carrot.carrotmarketclonecoding.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FailedMessage {
+    MEMBER_NOT_FOUND("존재하지 않는 사용자입니다!"),
+    CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다!"),
+    INPUT_NOT_VALID("입력값이 잘못되었습니다!");
+
+    private final String message;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -11,7 +11,8 @@ public enum FailedMessage {
     INPUT_NOT_VALID("입력값이 잘못되었습니다!"),
     FILE_EXTENSION_NOT_VALID("png 혹은 jpeg/jpg 파일이 아닙니다!"),
     FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다!"),
-    FILE_NOT_EXISTS("파일이 존재하지 않습니다!");
+    FILE_NOT_EXISTS("파일이 존재하지 않습니다!"),
+    FILE_UPLOAD_LIMIT("업로드 가능한 파일은 10개까지입니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -8,7 +8,10 @@ import lombok.Getter;
 public enum FailedMessage {
     MEMBER_NOT_FOUND("존재하지 않는 사용자입니다!"),
     CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다!"),
-    INPUT_NOT_VALID("입력값이 잘못되었습니다!");
+    INPUT_NOT_VALID("입력값이 잘못되었습니다!"),
+    FILE_EXTENSION_NOT_VALID("png 혹은 jpeg/jpg 파일이 아닙니다!"),
+    FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다!"),
+    FILE_NOT_EXISTS("파일이 존재하지 않습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/ResponseResult.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/ResponseResult.java
@@ -1,0 +1,22 @@
+package com.carrot.carrotmarketclonecoding.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public class ResponseResult {
+    private int status;
+    private Boolean result;
+    private String message;
+    private Object data;
+
+    public static ResponseResult success(HttpStatus status, String message, Object data) {
+        return new ResponseResult(status.value(), true, message, data);
+    }
+
+    public static ResponseResult failed(HttpStatus status, String message, Object data) {
+        return new ResponseResult(status.value(), false, message, data);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -1,0 +1,12 @@
+package com.carrot.carrotmarketclonecoding.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessMessage {
+    BOARD_REGISTER_SUCCESS("게시글 작성에 성공하였습니다!");
+
+    private final String message;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/utils/DecodeUtil.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/utils/DecodeUtil.java
@@ -1,0 +1,11 @@
+package com.carrot.carrotmarketclonecoding.common.utils;
+
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+public class DecodeUtil {
+
+    public static String decodeByUtf8(String url) {
+        return URLDecoder.decode(url, StandardCharsets.UTF_8);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/validation/EnumValidator.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/validation/EnumValidator.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.common.exception;
+package com.carrot.carrotmarketclonecoding.common.validation;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/validation/ValidEnum.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/validation/ValidEnum.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.common.exception;
+package com.carrot.carrotmarketclonecoding.common.validation;
 
 import jakarta.validation.Constraint;
 import jakarta.validation.Payload;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/AwsS3Config.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/AwsS3Config.java
@@ -1,0 +1,29 @@
+package com.carrot.carrotmarketclonecoding.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AwsS3Config {
+
+    @Value("${s3.board.accessKey}")
+    private String accessKey;
+
+    @Value("${s3.board.secretKey}")
+    private String secretKey;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .withRegion(Regions.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/JpaAuditingConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.carrot.carrotmarketclonecoding.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/file/service/FileService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/file/service/FileService.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.file.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface FileService {
+    String uploadImage(MultipartFile file);
+    void deleteUploadedImage(String url);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/file/service/impl/FileServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/file/service/impl/FileServiceImpl.java
@@ -1,0 +1,106 @@
+package com.carrot.carrotmarketclonecoding.file.service.impl;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.carrot.carrotmarketclonecoding.common.exception.FileExtensionNotValidException;
+import com.carrot.carrotmarketclonecoding.common.exception.FileUploadFailedException;
+import com.carrot.carrotmarketclonecoding.common.utils.DecodeUtil;
+import com.carrot.carrotmarketclonecoding.file.service.FileService;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FileServiceImpl implements FileService {
+    private static final String[] SUPPORTED_FILE_EXTENSIONS = {"image/jpeg", "image/png"};
+
+    private final AmazonS3 amazonS3Client;
+
+    @Value("${s3.board.bucket}")
+    private String bucket;
+
+    @Override
+    public String uploadImage(MultipartFile file) {
+        ObjectMetadata objectMetadata = createObjectMetadata(file);
+        String objectKey = createObjectKey(UUID.randomUUID().toString().toUpperCase(), file.getOriginalFilename());
+
+        log.debug("파일을 업로드합니다! {}", file.getOriginalFilename());
+        log.debug("확장자: {}", file.getContentType());
+        validateExtension(file.getContentType());
+
+        log.debug("originalFilename: {}", file.getOriginalFilename());
+        uploadImageToS3(file, objectKey, objectMetadata);
+
+        return amazonS3Client.getUrl(bucket, objectKey).toString();
+    }
+
+    @Override
+    public void deleteUploadedImage(String url) {
+        if (isUploadedImageExists(url)) {
+
+            log.debug("기존 사진을 삭제합니다! {}", url);
+
+            amazonS3Client.deleteObject(new DeleteObjectRequest(bucket, extractObjectKey(url)));
+        }
+    }
+
+    private void validateExtension(String contentType) {
+        if (!StringUtils.hasText(contentType) || Arrays.stream(SUPPORTED_FILE_EXTENSIONS).noneMatch(contentType::equals)) {
+            throw new FileExtensionNotValidException();
+        }
+    }
+
+    private ObjectMetadata createObjectMetadata(MultipartFile file) {
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentType(file.getContentType());
+        objectMetadata.setContentLength(file.getSize());
+        return objectMetadata;
+    }
+
+    private void uploadImageToS3(MultipartFile file, String objectKey, ObjectMetadata objectMetadata) {
+        try {
+            amazonS3Client.putObject(
+                    new PutObjectRequest(
+                            bucket,
+                            objectKey,
+                            file.getInputStream(),
+                            objectMetadata
+                    ));
+        } catch (IOException e) {
+            throw new FileUploadFailedException();
+        }
+    }
+
+    private Boolean isUploadedImageExists(String url) {
+        try {
+            String objectKey = DecodeUtil.decodeByUtf8(extractObjectKey(url));
+            amazonS3Client.getObject(bucket, objectKey);
+            return true;
+        } catch (Exception e) {
+            log.debug("사진이 존재하지 않습니다!");
+            return false;
+        }
+    }
+
+    private String extractObjectKey(String url) {
+        String[] parts = url.split("/");
+        if (parts.length > 0) {
+            return DecodeUtil.decodeByUtf8(parts[parts.length - 1]);
+        }
+        return "";
+    }
+
+    private String createObjectKey(String randomFilename, String originalFilename) {
+        return randomFilename + "_" + originalFilename;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
@@ -1,0 +1,33 @@
+package com.carrot.carrotmarketclonecoding.member.domain;
+
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Entity
+@Table(name = "members")
+public class Member extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String nickname;
+    private String profileUrl;
+    private String town;
+    private Boolean withdraw;
+    private Boolean isTownAuthenticated;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/enums/Role.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/enums/Role.java
@@ -1,0 +1,5 @@
+package com.carrot.carrotmarketclonecoding.member.domain.enums;
+
+public enum Role {
+    ADMIN, USER
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/repository/MemberRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/repository/MemberRepository.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.member.repository;
+
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,9 @@ encryptor:
 
 server:
   env: blue
+
+s3:
+  board:
+    bucket: ENC(bNnIVCrcukSCn+ewUyarhrco4Y6GDvwgUwtPhk/CcpRwGd3waQzxCA==)
+    accessKey: ENC(9I+FNe3mBV4sCcP+wF5Wo1E0tWxa5I6Qh2VpT0nHzuU=)
+    secretKey: ENC(h6QDcliPmdblNeU+SluXUxywb09NhatUUjRI9RJoaUcFkCOSieRxNcp9SXjQ1gWjjFufORPP2BA=)

--- a/src/main/resources/db/migration/V2__alter_table_boards.sql
+++ b/src/main/resources/db/migration/V2__alter_table_boards.sql
@@ -1,0 +1,36 @@
+ALTER TABLE boards
+    ADD COLUMN category_id BIGINT;
+
+ALTER TABLE boards
+    ADD CONSTRAINT fk_category
+        FOREIGN KEY (category_id) REFERENCES categories (id);
+
+drop table board_categories;
+
+alter table members
+    change column is_authenticated is_town_authenticated TINYINT(1);
+
+alter table members
+    add column role VARCHAR(10);
+
+insert into categories
+    values (1, '디지털기기', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (2, '생활가전', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (3, '가구/인테리어', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (4, '생활/주방', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (5, '유아동', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (6, '유아도서', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (7, '여성의류', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (8, '여성잡화', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (9, '남성패션/잡화', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (10, '뷰티/미용', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (11, '스포츠/레저', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (12, '취미/게임/음반', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (13, '도서', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (14, '티켓/교환권', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (15, '가공식품', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (16, '건강기능식품', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (17, '반려동물용품', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (18, '식물', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (19, '기타 중고물품', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP),
+        (20, '삽니다', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/test/application-test.yml
+++ b/src/test/application-test.yml
@@ -1,4 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: test

--- a/src/test/java/com/carrot/carrotmarketclonecoding/CarrotMarketCloneCodingApplicationTests.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/CarrotMarketCloneCodingApplicationTests.java
@@ -4,7 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-//@ActiveProfiles("test")
 @SpringBootTest
 class CarrotMarketCloneCodingApplicationTests {
 

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -1,0 +1,166 @@
+package com.carrot.carrotmarketclonecoding.board.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CATEGORY_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE;
+import com.carrot.carrotmarketclonecoding.board.service.impl.BoardServiceImpl;
+import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.response.FailedMessage;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BoardController.class)
+class BoardControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    BoardServiceImpl boardService;
+
+    @Nested
+    @DisplayName("게시글 작성 컨트롤러 테스트")
+    class BoardRegisterControllerTest {
+
+        @Test
+        @DisplayName("성공")
+        void boardRegister() throws Exception {
+            // given
+            BoardRegisterRequestDto requestDto = BoardRegisterRequestDto.builder()
+                    .pictures(null)
+                    .title("title")
+                    .categoryId(1L)
+                    .method(Method.SELL)
+                    .price(200000)
+                    .suggest(true)
+                    .description("description")
+                    .place("place")
+                    .tmp(false)
+                    .build();
+
+            // when
+            // then
+            mvc.perform(post("/board/register")
+                    .content(new ObjectMapper().writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status", equalTo(201)))
+                    .andExpect(jsonPath("$.result", equalTo(true)))
+                    .andExpect(jsonPath("$.message", equalTo(BOARD_REGISTER_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+
+        }
+
+        @Test
+        @DisplayName("실패 - 유효성 검사 실패")
+        void boardRegisterValidationFailed() throws Exception {
+            // given
+            BoardRegisterRequestDto requestDto = BoardRegisterRequestDto.builder()
+                    .pictures(null)
+                    .title("")
+                    .categoryId(1L)
+                    .method(Method.SELL)
+                    .price(200000)
+                    .suggest(true)
+                    .description("description")
+                    .place("place")
+                    .tmp(false)
+                    .build();
+
+            Map<String, String> map = new HashMap<>();
+            map.put("title", MESSAGE.TITLE_NOT_VALID);
+
+            // when
+            // then
+            mvc.perform(post("/board/register")
+                    .content(new ObjectMapper().writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(FailedMessage.INPUT_NOT_VALID.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(map)));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 작성자")
+        void boardRegisterMemberNotFound() throws Exception {
+            // given
+            BoardRegisterRequestDto requestDto = BoardRegisterRequestDto.builder()
+                    .pictures(null)
+                    .title("title")
+                    .categoryId(1L)
+                    .method(Method.SELL)
+                    .price(200000)
+                    .suggest(true)
+                    .description("description")
+                    .place("place")
+                    .tmp(false)
+                    .build();
+
+            // when
+            when(boardService.register(any(), anyLong())).thenThrow(MemberNotFoundException.class);
+
+            // then
+            mvc.perform(post("/board/register")
+                    .content(new ObjectMapper().writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status", equalTo(401)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void boardRegisterCategoryNotFound() throws Exception {
+            // given
+            BoardRegisterRequestDto requestDto = BoardRegisterRequestDto.builder()
+                    .pictures(null)
+                    .title("title")
+                    .categoryId(1L)
+                    .method(Method.SELL)
+                    .price(200000)
+                    .suggest(true)
+                    .description("description")
+                    .place("place")
+                    .tmp(false)
+                    .build();
+
+            // when
+            when(boardService.register(any(), anyLong())).thenThrow(CategoryNotFoundException.class);
+
+            // then
+            mvc.perform(post("/board/register")
+                    .content(new ObjectMapper().writeValueAsString(requestDto))
+                    .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(CATEGORY_NOT_FOUND.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -1,0 +1,124 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.Category;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
+import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
+import com.carrot.carrotmarketclonecoding.board.service.impl.BoardServiceImpl;
+import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.response.FailedMessage;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BoardServiceTest {
+
+    @InjectMocks
+    private BoardServiceImpl boardService;
+
+    @Mock
+    private BoardRepository boardRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Nested
+    @DisplayName("게시글 작성 서비스 테스트")
+    class RegisterBoard {
+
+        @Test
+        @DisplayName("성공")
+        void registerBoard() {
+            // given
+            Long memberId = 1L;
+            Long categoryId = 1L;
+            Long boardId = 1L;
+            BoardRegisterRequestDto boardRegisterRequestDto = createRegisterRequestDto(categoryId);
+
+            Member mockMember = Member.builder().id(memberId).build();
+            Category mockCategory = Category.builder().id(categoryId).build();
+            Board mockBoard = Board.builder().id(boardId).build();
+
+            when(memberRepository.findById(any())).thenReturn(Optional.of(mockMember));
+            when(categoryRepository.findById(any())).thenReturn(Optional.of(mockCategory));
+            when(boardRepository.save(any())).thenReturn(mockBoard);
+
+            // when
+            Long registeredBoardId = boardService.register(boardRegisterRequestDto, memberId);
+
+            // then
+            assertThat(registeredBoardId).isEqualTo(boardId);
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 작성자")
+        void registerBoardMemberNotFound() {
+            // given
+            Long memberId = 1L;
+            Long categoryId = 1L;
+            BoardRegisterRequestDto boardRegisterRequestDto = createRegisterRequestDto(categoryId);
+
+            Member mockMember = Member.builder().id(memberId).build();
+
+            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(categoryRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> boardService.register(boardRegisterRequestDto, memberId))
+                    .isInstanceOf(CategoryNotFoundException.class)
+                    .hasMessage(FailedMessage.CATEGORY_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 카테고리")
+        void registerBoardCategoryNotFound() {
+            // given
+            Long memberId = 1L;
+            Long categoryId = 1L;
+            BoardRegisterRequestDto boardRegisterRequestDto = createRegisterRequestDto(categoryId);
+
+            when(memberRepository.findById(any())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> boardService.register(boardRegisterRequestDto, memberId))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+
+        private BoardRegisterRequestDto createRegisterRequestDto(Long categoryId) {
+            return BoardRegisterRequestDto.builder()
+                    .pictures(null)
+                    .title("title")
+                    .categoryId(categoryId)
+                    .method(Method.SELL)
+                    .price(200000)
+                    .suggest(true)
+                    .description("description")
+                    .place("place")
+                    .tmp(false)
+                    .build();
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -10,3 +10,9 @@ spring:
 
 encryptor:
   key: ${JASYPT_KEY}
+
+s3:
+  board:
+    bucket: ENC(DYBumT/r/jJNVv0aIdXL0suri5bX5EeMZse+xuS5mfI=)
+    accessKey: ENC(9I+FNe3mBV4sCcP+wF5Wo1E0tWxa5I6Qh2VpT0nHzuU=)
+    secretKey: ENC(h6QDcliPmdblNeU+SluXUxywb09NhatUUjRI9RJoaUcFkCOSieRxNcp9SXjQ1gWjjFufORPP2BA=)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  flyway:
+    enabled: false
+
+encryptor:
+  key: ${JASYPT_KEY}


### PR DESCRIPTION
## 구현 기능
- 커스텀 예외 클래스를 위한 추상 클래스 생성 및 사용
- 거래 게시글 작성 기능
- 사진은 10개까지 업로드 가능
- 업로드 요청한 사진의 개수가 10개를 넘을 경우 게시글만 저장되고 사진은 저장되지 않음
- 업로드 요청한 사진 중 이미지 파일이 아닌 파일의 경우 업로드 수행 x
- 나눔게시판 업로드 경우 가격 0으로 설정
- 입력값에 대한 유효성 검사 후 유효하지 않은 필드에 대해서 응답
- 작성자 정보가 데이터베이스에 존재하지 않을 경우 예외발생 및 에러메시지 응답
- 설정한 카테고리에 대한 정보가 데이터베이스에 존재하지 않을 경우 예외발생 및 에러메시지 응답

## 관련 이슈
resolved #11 
