### PR TITLE
업로드 요청 사진파일의 개수 파악 불가 버그 해결

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -58,7 +58,7 @@ public class BoardServiceImpl implements BoardService {
     }
 
     private void validatePictures(MultipartFile[] pictures) {
-        if (pictures.length > FILE_LIMIT_COUNT) {
+        if (pictures != null && pictures.length > FILE_LIMIT_COUNT) {
             throw new FileUploadLimitException();
         }
     }


### PR DESCRIPTION
### 구현한 기능
업로드 요청한 사진배열이 Null인지 파악하는 검사 로직 추가

### 관련 이슈
resolved #19 