### PR TITLE
[BUG]: 상품 설명문 유효성검사 로직 구현 필요

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -36,7 +36,8 @@ public class BoardRequestDto {
         @NotNull(message = SUGGEST_NOT_VALID)
         private Boolean suggest;
 
-        @Size(max = 300, message = DESCRIPTION_NOT_VALID)
+        @NotEmpty(message = DESCRIPTION_NOT_VALID)
+        @Size(max = 300, message = DESCRIPTION_OVER_LENGTH)
         private String description;
 
         @NotEmpty(message = PLACE_NOT_VALID)

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/validation/BoardRegisterValidationMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/validation/BoardRegisterValidationMessage.java
@@ -20,7 +20,8 @@ public enum BoardRegisterValidationMessage {
         public static final String CATEGORY_NOT_VALID = "카테고리는 필수 입력사항입니다!";
         public static final String PRICE_NOT_VALID = "가격은 필수 입력사항입니다!";
         public static final String SUGGEST_NOT_VALID = "거래제안받기여부는 필수 입력사항입니다!";
-        public static final String DESCRIPTION_NOT_VALID = "상품 설명은 300글자 이내여야 합니다!";
+        public static final String DESCRIPTION_NOT_VALID = "상품설명은 필수 입력값입니다!";
+        public static final String DESCRIPTION_OVER_LENGTH = "상품 설명은 300글자 이내여야 합니다!";
         public static final String PLACE_NOT_VALID = "거래희망장소는 필수 입력사항입니다!";
     }
 }


### PR DESCRIPTION
### 구현 기능
거래 게시글의 description 필드에 대한 유효성 검사 로직 추가 및 유효성 검사 실패 메시지(설명문을 적지 않았을 경우) enum 값 추가

### 관련 이슈
resolved #20 