### PR TITLE
게시글 상세 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
     // S3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.690'
+
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation "org.testcontainers:testcontainers"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -1,15 +1,19 @@
 package com.carrot.carrotmarketclonecoding.board.controller;
 
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_GET_DETAIL_SUCCESS;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_SUCCESS;
 
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -27,5 +31,15 @@ public class BoardController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ResponseResult.success(HttpStatus.CREATED, BOARD_REGISTER_SUCCESS.getMessage(), null));
+    }
+
+    @GetMapping("/board/{id}")
+    public ResponseEntity<?> detail(@PathVariable("id") Long id) {
+        // TODO memberId -> JWT.getMemberId()
+        Long memberId = 1L;
+        BoardDetailResponseDto boardDetail = boardService.detail(id, memberId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_DETAIL_SUCCESS.getMessage(), boardDetail));
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
@@ -60,6 +60,10 @@ public class Board extends BaseEntity {
 
     private Boolean tmp;
 
+    public void increaseVisit() {
+        this.visit += 1;
+    }
+
     public static Board createBoard(BoardRegisterRequestDto boardInputRequestDto, Member member, Category category) {
         return Board.builder()
                 .title(boardInputRequestDto.getTitle())

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/BoardLike.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/BoardLike.java
@@ -1,0 +1,35 @@
+package com.carrot.carrotmarketclonecoding.board.domain;
+
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "board_likes")
+public class BoardLike extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
@@ -2,6 +2,7 @@ package com.carrot.carrotmarketclonecoding.board.dto;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -30,8 +31,10 @@ public class BoardResponseDto {
         private Status status;
         private String title;
         private String category;
+        private Method method;
+        private int price;
         private Boolean suggest;
-        private LocalDateTime createdDate;
+        private LocalDateTime createDate;
         private String description;
         private List<PictureResponseDto> pictures = new ArrayList<>();
         private int chat;
@@ -47,8 +50,10 @@ public class BoardResponseDto {
                     .status(board.getStatus())
                     .title(board.getTitle())
                     .category(board.getCategory().getName())
+                    .method(board.getMethod())
+                    .price(board.getPrice())
                     .suggest(board.getSuggest())
-                    .createdDate(board.getCreateDate())
+                    .createDate(board.getCreateDate())
                     .description(board.getDescription())
                     .pictures(pictures.stream()
                             .map(PictureResponseDto::createPictureDetail)

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
@@ -1,0 +1,79 @@
+package com.carrot.carrotmarketclonecoding.board.dto;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+public class BoardResponseDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class BoardDetailResponseDto {
+        private Long id;
+        private String writer;
+        private String place;
+        private String profileUrl;
+        private Status status;
+        private String title;
+        private String category;
+        private Boolean suggest;
+        private LocalDateTime createdDate;
+        private String description;
+        private List<PictureResponseDto> pictures = new ArrayList<>();
+        private int chat;
+        private int like;
+        private int visit;
+
+        public static BoardDetailResponseDto createBoardDetail(Board board, List<BoardPicture> pictures, int like) {
+            return BoardDetailResponseDto.builder()
+                    .id(board.getId())
+                    .writer(board.getMember().getNickname())
+                    .place(board.getPlace())
+                    .profileUrl(board.getMember().getProfileUrl())
+                    .status(board.getStatus())
+                    .title(board.getTitle())
+                    .category(board.getCategory().getName())
+                    .suggest(board.getSuggest())
+                    .createdDate(board.getCreateDate())
+                    .description(board.getDescription())
+                    .pictures(pictures.stream()
+                            .map(PictureResponseDto::createPictureDetail)
+                            .collect(Collectors.toList()))
+                    .like(like)
+                    .visit(board.getVisit())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    @ToString
+    public static class PictureResponseDto {
+        private Long id;
+        private String pictureUrl;
+
+        public static PictureResponseDto createPictureDetail(BoardPicture boardPicture) {
+            return PictureResponseDto.builder()
+                    .id(boardPicture.getId())
+                    .pictureUrl(boardPicture.getPictureUrl())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
@@ -1,0 +1,9 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    int countByBoard(Board board);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
@@ -1,8 +1,10 @@
 package com.carrot.carrotmarketclonecoding.board.repository;
 
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardPictureRepository extends JpaRepository<BoardPicture, Long> {
-
+    List<BoardPicture> findByBoard(Board board);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -1,7 +1,10 @@
 package com.carrot.carrotmarketclonecoding.board.service;
 
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 
 public interface BoardService {
     Long register(BoardRegisterRequestDto inputRequestDto, Long memberId);
+
+    BoardDetailResponseDto detail(Long boardId, Long memberId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
@@ -1,0 +1,24 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class VisitService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String BOARD_VISIT_KEY = "board:visit:";
+
+    public boolean increaseVisit(String boardId, String memberId) {
+        String visitKey = BOARD_VISIT_KEY + boardId;
+        SetOperations<String, String> setOps = redisTemplate.opsForSet();
+        boolean isFirstTimeView =  setOps.add(visitKey, memberId) > 0;
+        redisTemplate.expire(visitKey, 1, TimeUnit.DAYS);
+
+        return isFirstTimeView;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -5,16 +5,21 @@ import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
 import com.carrot.carrotmarketclonecoding.board.domain.Category;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
+import com.carrot.carrotmarketclonecoding.board.service.VisitService;
+import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.file.service.impl.FileServiceImpl;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,7 +33,9 @@ public class BoardServiceImpl implements BoardService {
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
     private final BoardPictureRepository boardPictureRepository;
+    private final BoardLikeRepository boardLikeRepository;
     private final FileServiceImpl fileService;
+    private final VisitService visitService;
 
     private final int FILE_LIMIT_COUNT = 10;
 
@@ -49,6 +56,22 @@ public class BoardServiceImpl implements BoardService {
         }
 
         return board.getId();
+    }
+
+    @Override
+    public BoardDetailResponseDto detail(Long boardId, Long memberId) {
+        Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
+        List<BoardPicture> pictures = boardPictureRepository.findByBoard(board);
+        int like = boardLikeRepository.countByBoard(board);
+
+        if (visitService.increaseVisit(board.getId().toString(), memberId.toString())) {
+            board.increaseVisit();
+            boardRepository.save(board);
+        }
+
+        // TODO count chats
+
+        return BoardDetailResponseDto.createBoardDetail(board, pictures, like);
     }
 
     private void checkMethod(BoardRegisterRequestDto registerRequestDto) {

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/BoardNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/BoardNotFoundException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.BOARD_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class BoardNotFoundException extends CustomException
+{
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return BOARD_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum FailedMessage {
     MEMBER_NOT_FOUND("존재하지 않는 사용자입니다!"),
     CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다!"),
+    BOARD_NOT_FOUND("존재하지 않는 게시글입니다!"),
     INPUT_NOT_VALID("입력값이 잘못되었습니다!"),
     FILE_EXTENSION_NOT_VALID("png 혹은 jpeg/jpg 파일이 아닙니다!"),
     FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다!"),

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessMessage {
-    BOARD_REGISTER_SUCCESS("게시글 작성에 성공하였습니다!");
+    BOARD_REGISTER_SUCCESS("게시글 작성에 성공하였습니다!"),
+    BOARD_GET_DETAIL_SUCCESS("게시글 조회에 성공하였습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/RedisConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/RedisConfig.java
@@ -1,0 +1,37 @@
+package com.carrot.carrotmarketclonecoding.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -9,6 +9,14 @@ spring:
     username: root
     password: ENC(IodgSOc+Fl9zsU7t261DauMaJCjRPSNq)
 
+  data:
+    redis:
+      host: ENC(PgnZGrO2VsW7JQAPvnYD7spp5X0nxFWX)
+      port: 6379
+
+  jpa:
+    show-sql: false
+
 server:
   env: blue
   port: 8080

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -9,6 +9,14 @@ spring:
     username: root
     password: ENC(IodgSOc+Fl9zsU7t261DauMaJCjRPSNq)
 
+  data:
+    redis:
+      host: ENC(PgnZGrO2VsW7JQAPvnYD7spp5X0nxFWX)
+      port: 6379
+
+  jpa:
+    show-sql: false
+
 server:
   env: green
   port: 8081

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -9,6 +9,18 @@ spring:
     username: root
     password: ENC(IodgSOc+Fl9zsU7t261DauMaJCjRPSNq)
 
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
+
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+
 server:
   env: local
   port: 8080

--- a/src/test/java/com/carrot/carrotmarketclonecoding/CarrotMarketCloneCodingApplicationTests.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/CarrotMarketCloneCodingApplicationTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class CarrotMarketCloneCodingApplicationTests {
 

--- a/src/test/java/com/carrot/carrotmarketclonecoding/RedisContainerConfig.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/RedisContainerConfig.java
@@ -1,0 +1,26 @@
+package com.carrot.carrotmarketclonecoding;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+@ActiveProfiles("test")
+public class RedisContainerConfig implements BeforeAllCallback {
+    private static final String REDIS_IMAGE = "redis:7.4.0-alpine";
+    private static final int REDIS_PORT = 6379;
+
+    private GenericContainer redisContainer;
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        redisContainer = new GenericContainer(DockerImageName.parse(REDIS_IMAGE))
+                .withExposedPorts(REDIS_PORT)
+                .withReuse(true);
+        redisContainer.start();
+
+        System.setProperty("spring.data.redis.host", redisContainer.getHost());
+        System.setProperty("spring.data.redis.port", redisContainer.getMappedPort(6379).toString());
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -1,21 +1,21 @@
 package com.carrot.carrotmarketclonecoding.board.controller;
 
-import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CATEGORY_NOT_FOUND;
-import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FILE_UPLOAD_LIMIT;
-import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.INPUT_NOT_VALID;
-import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
-import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardServiceImpl;
+import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
@@ -187,6 +187,50 @@ class BoardControllerTest {
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
                     .andExpect(jsonPath("$.message", equalTo(CATEGORY_NOT_FOUND.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+    }
+
+    @Nested
+    @DisplayName("게시글 조회 컨트롤러 테스트")
+    class BoardDetail {
+
+        @Test
+        @DisplayName("성공")
+        void boardDetailSuccess() throws Exception {
+            // given
+            Long boardId = 1L;
+            BoardDetailResponseDto response = BoardDetailResponseDto.builder()
+                    .id(boardId)
+                    .build();
+
+            // when
+            when(boardService.detail(anyLong(), anyLong())).thenReturn(response);
+
+            // then
+            mvc.perform(get("/board/{id}", boardId))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.result", equalTo(true)))
+                    .andExpect(jsonPath("$.message", equalTo(BOARD_GET_DETAIL_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data.id", equalTo(boardId.intValue())));
+        }
+
+        @Test
+        @DisplayName("실패 - 존재하지 않는 게시판 아이디")
+        void boardDetailBoardNotFound() throws Exception {
+            // given
+            Long boardId = 1L;
+
+            // when
+            when(boardService.detail(anyLong(), anyLong())).thenThrow(new BoardNotFoundException());
+
+            // then
+            mvc.perform(get("/board/{id}", boardId))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(BOARD_NOT_FOUND.getMessage())))
                     .andExpect(jsonPath("$.data", equalTo(null)));
         }
     }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepositoryTest.java
@@ -1,0 +1,35 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardLike;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class BoardLikeRepositoryTest {
+
+    @Autowired
+    private BoardLikeRepository boardLikeRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("쿼리메소드 countByBoard() 테스트")
+    void countByBoard() {
+        // given
+        Board board = boardRepository.save(Board.builder().build());
+        boardLikeRepository.save(BoardLike.builder().board(board).build());
+        boardLikeRepository.save(BoardLike.builder().board(board).build());
+
+        // when
+        int result = boardLikeRepository.countByBoard(board);
+
+        // then
+        assertThat(result).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.carrot.carrotmarketclonecoding.board.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class BoardPictureRepositoryTest {
+
+    @Autowired
+    private BoardPictureRepository boardPictureRepository;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Test
+    @DisplayName("쿼리메소드 findByBoard() 테스트")
+    void findByBoard() {
+        // given
+        Board board = boardRepository.save(Board.builder().build());
+        boardPictureRepository.save(BoardPicture.builder().board(board).build());
+        boardPictureRepository.save(BoardPicture.builder().board(board).build());
+
+        // when
+        List<BoardPicture> boardPictures = boardPictureRepository.findByBoard(board);
+
+        // then
+        assertThat(boardPictures.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/VisitServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/VisitServiceTest.java
@@ -1,0 +1,43 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrot.carrotmarketclonecoding.RedisContainerConfig;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataRedisTest
+@ExtendWith(RedisContainerConfig.class)
+class VisitServiceTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String BOARD_VISIT_KEY = "board:visit:";
+
+    @Test
+    @DisplayName("레디스 컨테이너를 사용해 게시판 set에 memberId value 저장 테스트")
+    void testIncrementVisit() {
+        // given
+        String boardId = "1";
+        String memberId = "1";
+        String visitKey = BOARD_VISIT_KEY + boardId;
+        SetOperations<String, String> setOperations = redisTemplate.opsForSet();
+
+        // when
+        boolean isFirstTimeView =  setOperations.add(visitKey, memberId) > 0;
+        redisTemplate.expire(visitKey, 1, TimeUnit.MINUTES);
+
+        // then
+        assertThat(isFirstTimeView).isEqualTo(true);
+        assertThat(setOperations.pop(visitKey)).isEqualTo("1");
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,4 +1,8 @@
 spring:
+  config:
+    activate:
+      on-profile: test
+
   datasource:
     url: jdbc:h2:mem:testdb;MODE=MYSQL
     driver-class-name: org.h2.Driver
@@ -7,6 +11,11 @@ spring:
 
   flyway:
     enabled: false
+
+  data:
+    redis:
+      host: 127.0.0.1
+      port: 6379
 
 encryptor:
   key: ${JASYPT_KEY}


### PR DESCRIPTION
### 구현 기능
- 게시글 아이디를 통해 특정 게시글 상세 조회 기능 구현
- 사용자가 24시간내에 해당 게시글을 조회한 이력이 있을 경우 조회수는 증가하지 않음
- 24시간내에 조회한 적이 없을 경우 레디스에 조회 이력을 저장하고 데이터베이스 내용 업데이트 후 저장
- 레디스 테스트는 TestContainer를 통해 도커를 실행하고 테스트가 끝나면 컨테이너를 닫는 형식으로 진행
(Embedded Redis는 m1에서 돌아가지 않아 선택x)


### 관련 이슈
resolved #14 