### PR TITLE
[BUG]: 사용자 조회이력 공유 버그 해결

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
@@ -3,7 +3,6 @@ package com.carrot.carrotmarketclonecoding.board.service;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,14 +10,16 @@ import org.springframework.stereotype.Service;
 public class VisitService {
     private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String BOARD_VISIT_KEY = "board:visit:";
+    private static final String BOARD_VISIT_KEY_PREFIX = "board:visit:";
 
     public boolean increaseVisit(String boardId, String memberId) {
-        String visitKey = BOARD_VISIT_KEY + boardId;
-        SetOperations<String, String> setOps = redisTemplate.opsForSet();
-        boolean isFirstTimeView =  setOps.add(visitKey, memberId) > 0;
-        redisTemplate.expire(visitKey, 1, TimeUnit.DAYS);
+        String key = BOARD_VISIT_KEY_PREFIX + boardId + ":" + memberId;
+        Boolean memberViewed = redisTemplate.hasKey(key);
+        if (memberViewed != null && !memberViewed) {
+            redisTemplate.opsForValue().set(key, "1", 24, TimeUnit.HOURS);
+            return true;
+        }
 
-        return isFirstTimeView;
+        return false;
     }
 }


### PR DESCRIPTION
### 버그 내용
같은 게시글을 조회할 때 사용자가 조회한 이력에 대한 레디스 데이터가 만료될경우 다른 사용자의 조회한 이력도 만료되는 버그.
같은 게시글에 대한 Set 자료구조에 모두 저장하기 때문에 해당 자료구조가 만료될경우 다른 사용자의 조회이력도 삭제.

### 관련 이슈
resolved #26 