### PR TITLE
[BUG] 비회원에 대해서는 조회수 관리가 안되는 문제 해결

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegiste
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import jakarta.servlet.http.HttpSession;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -34,10 +35,8 @@ public class BoardController {
     }
 
     @GetMapping("/board/{id}")
-    public ResponseEntity<?> detail(@PathVariable("id") Long id) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        BoardDetailResponseDto boardDetail = boardService.detail(id, memberId);
+    public ResponseEntity<?> detail(@PathVariable("id") Long id, HttpSession session) {
+        BoardDetailResponseDto boardDetail = boardService.detail(id, session.getId());
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_DETAIL_SUCCESS.getMessage(), boardDetail));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -6,5 +6,5 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetail
 public interface BoardService {
     Long register(BoardRegisterRequestDto inputRequestDto, Long memberId);
 
-    BoardDetailResponseDto detail(Long boardId, Long memberId);
+    BoardDetailResponseDto detail(Long boardId, String sessionId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
@@ -12,14 +12,20 @@ public class VisitService {
 
     private static final String BOARD_VISIT_KEY_PREFIX = "board:visit:";
 
-    public boolean increaseVisit(String boardId, String memberId) {
-        String key = BOARD_VISIT_KEY_PREFIX + boardId + ":" + memberId;
-        Boolean memberViewed = redisTemplate.hasKey(key);
-        if (memberViewed != null && !memberViewed) {
-            redisTemplate.opsForValue().set(key, "1", 24, TimeUnit.HOURS);
+    public boolean increaseVisit(String boardId, String sessionId) {
+        String sessionKey = BOARD_VISIT_KEY_PREFIX + boardId + ":session:" + sessionId;
+        Boolean viewed = redisTemplate.hasKey(sessionKey);
+        if (sessionId != null && sessionId.length() > 0) {
+            return setSessionKey(viewed, sessionKey);
+        }
+        return false;
+    }
+
+    private boolean setSessionKey(Boolean viewed, String sessionKey) {
+        if (viewed != null && !viewed) {
+            redisTemplate.opsForValue().set(sessionKey, "1", 24, TimeUnit.HOURS);
             return true;
         }
-
         return false;
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -21,11 +21,9 @@ import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BoardServiceImpl implements BoardService {
@@ -59,12 +57,12 @@ public class BoardServiceImpl implements BoardService {
     }
 
     @Override
-    public BoardDetailResponseDto detail(Long boardId, Long memberId) {
+    public BoardDetailResponseDto detail(Long boardId, String sessionId) {
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         List<BoardPicture> pictures = boardPictureRepository.findByBoard(board);
         int like = boardLikeRepository.countByBoard(board);
 
-        if (visitService.increaseVisit(board.getId().toString(), memberId.toString())) {
+        if (visitService.increaseVisit(board.getId().toString(), sessionId)) {
             board.increaseVisit();
             boardRepository.save(board);
         }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -5,6 +5,7 @@ import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
@@ -205,7 +206,7 @@ class BoardControllerTest {
                     .build();
 
             // when
-            when(boardService.detail(anyLong(), anyLong())).thenReturn(response);
+            when(boardService.detail(anyLong(), anyString())).thenReturn(response);
 
             // then
             mvc.perform(get("/board/{id}", boardId))
@@ -223,7 +224,7 @@ class BoardControllerTest {
             Long boardId = 1L;
 
             // when
-            when(boardService.detail(anyLong(), anyLong())).thenThrow(new BoardNotFoundException());
+            when(boardService.detail(anyLong(), anyString())).thenThrow(new BoardNotFoundException());
 
             // then
             mvc.perform(get("/board/{id}", boardId))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -227,6 +227,7 @@ class BoardServiceTest {
             // given
             Long boardId = 1L;
             Long memberId = 1L;
+            String sessionId = "session:" + memberId;
             Board mockBoard = createMockBoard(boardId, memberId);
 
             List<BoardPicture> mockPictures = Arrays.asList(
@@ -239,7 +240,7 @@ class BoardServiceTest {
             when(visitService.increaseVisit(anyString(), anyString())).thenReturn(true);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, memberId);
+            BoardDetailResponseDto result = boardService.detail(boardId, sessionId);
 
             // then
             assertThat(result.getId()).isEqualTo(boardId);
@@ -273,7 +274,7 @@ class BoardServiceTest {
             when(visitService.increaseVisit(anyString(), anyString())).thenReturn(false);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, memberId);
+            BoardDetailResponseDto result = boardService.detail(boardId, "sessionId:" + memberId);
 
             // then
             assertThat(result.getVisit()).isEqualTo(10);
@@ -289,7 +290,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.detail(boardId, memberId))
+            assertThatThrownBy(() -> boardService.detail(boardId, "sessionId:" + memberId))
                     .isInstanceOf(BoardNotFoundException.class)
                     .hasMessage(BOARD_NOT_FOUND.getMessage());
         }


### PR DESCRIPTION
### 구현 기능
현재 로그인한 사용자의 ID로 레디스에 저장하는 것이 아닌 현재 브라우저에 접속한 사용자의 Session ID를 기반으로 레디스에 조회 내역 저장.

### 관련 이슈
resolved #30 