### PR TITLE
판매중/판매완료 게시글 검색 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -72,10 +72,20 @@ public class BoardController {
 
     @GetMapping
     public ResponseEntity<?> search(BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
-        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(searchRequestDto, pageable);
+        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(null, searchRequestDto, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_DETAIL_SUCCESS.getMessage(), boards));
+                .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<?> searchBoardsByStatus(BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
+        // TODO memberId -> JWT.getMemberId()
+        Long memberId = 1L;
+        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(memberId, searchRequestDto, pageable);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
     }
 
     @PatchMapping("/{id}")

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -4,6 +4,7 @@ import static com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegis
 
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.SearchOrder;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import com.carrot.carrotmarketclonecoding.common.validation.ValidEnum;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
@@ -90,5 +91,6 @@ public class BoardRequestDto {
         private Integer minPrice;
         private Integer maxPrice;
         private SearchOrder order;
+        private Status status;
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
@@ -7,7 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepositoryCustom {
-    Page<BoardSearchResponseDto> searchBoards(BoardSearchRequestDto searchRequestDto, Pageable pageable);
+    Page<BoardSearchResponseDto> findAllByMemberAndSearchRequestDto(Member member, BoardSearchRequestDto searchRequestDto, Pageable pageable);
 
     Page<BoardSearchResponseDto> searchMemberLikedBoards(Member member, Pageable pageable);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.carrot.carrotmarketclonecoding.board.service;
 
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
@@ -15,7 +16,7 @@ public interface BoardService {
 
     BoardDetailResponseDto tmpBoardDetail(Long memberId);
 
-    PageResponseDto<BoardSearchResponseDto> search(BoardSearchRequestDto searchRequestDto, Pageable pageable);
+    PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable);
 
     void update(BoardUpdateRequestDto updateRequestDto, Long boardId, Long memberId);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -82,8 +82,12 @@ public class BoardServiceImpl implements BoardService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponseDto<BoardSearchResponseDto> search(BoardSearchRequestDto searchRequestDto, Pageable pageable) {
-        return new PageResponseDto<>(boardRepository.searchBoards(searchRequestDto, pageable));
+    public PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable) {
+        Member member = null;
+        if (memberId != null) {
+            member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        }
+        return new PageResponseDto<>(boardRepository.findAllByMemberAndSearchRequestDto(member, searchRequestDto, pageable));
     }
 
     @Override

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -13,7 +13,8 @@ public enum SuccessMessage {
     BOARD_DELETE_SUCCESS("게시글 삭제에 성공하였습니다!"),
     BOARD_GET_TMP_SUCCESS("임시 게시글 조회에 성공하였습니다!"),
     ADD_BOARD_LIKE_SUCCESS("관심게시글 등록에 성공하였습니다!"),
-    GET_MEMBER_LIKED_BOARDS_SUCCESS("게시글 목록 조회에 성공하였습니다!");
+    GET_MEMBER_LIKED_BOARDS_SUCCESS("관심 게시글 목록 조회에 성공하였습니다!"),
+    SEARCH_BOARDS_SUCCESS("게시글 검색에 성공하였습니다!");
 
     private final String message;
 }


### PR DESCRIPTION
### 구현 기능
현재 사용자의 판매중/판매완료 상태로 게시글 목록을 검색하는 기능 구현.
기존 `search()` Querydsl을 수정해 기존 '게시글 검색' 기능에서 검색 파라미터에 Status만 추가해 재사용하는 것으로 구현.
컨트롤러는 따로 두는 것으로 구현(일반 게시글 검색 : /board, 상태값으로 현재 사용자의 게시글 검색 : /board/status)
추후에 SpringSecurity 구현 전략에 따라 바뀔 예정.

### 관련 이슈
resolved #40 #41