### PR TITLE
[BUG] 이미 관심게시글로 등록한 게시글에 대해서 계속 등록이 가능한 버그 해결

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
@@ -2,8 +2,11 @@ package com.carrot.carrotmarketclonecoding.board.repository;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardLike;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     int countByBoard(Board board);
+    Optional<BoardLike> findByBoardAndMember(Board board, Member member);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
@@ -7,10 +7,12 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardLikeService;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberAlreadyLikedBoardException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -28,11 +30,16 @@ public class BoardLikeServiceImpl implements BoardLikeService {
     public void add(Long boardId, Long memberId) {
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        BoardLike boardLike = BoardLike.builder()
+
+        Optional<BoardLike> boardLike = boardLikeRepository.findByBoardAndMember(board, member);
+        if (boardLike.isPresent()) {
+            throw new MemberAlreadyLikedBoardException();
+        }
+
+        boardLikeRepository.save(BoardLike.builder()
                 .board(board)
                 .member(member)
-                .build();
-        boardLikeRepository.save(boardLike);
+                .build());
     }
 
     @Override

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/MemberAlreadyLikedBoardException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/MemberAlreadyLikedBoardException.java
@@ -1,0 +1,17 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_ALREADY_LIKED_BOARD;
+
+import org.springframework.http.HttpStatus;
+
+public class MemberAlreadyLikedBoardException extends CustomException {
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return MEMBER_ALREADY_LIKED_BOARD.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -15,7 +15,7 @@ public enum FailedMessage {
     FILE_NOT_EXISTS("파일이 존재하지 않습니다!"),
     FILE_UPLOAD_LIMIT("업로드 가능한 파일은 10개까지입니다!"),
     UNAUTHORIZED_ACCESS("접근권한을 가지고 있지 않습니다!"),
-    MEMBER_ALREADY_LIKED_BOARD("이미 좋아요한 게시글입니다!");
+    MEMBER_ALREADY_LIKED_BOARD("이미 관심게시글로 등록한 게시글입니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -14,7 +14,8 @@ public enum FailedMessage {
     FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다!"),
     FILE_NOT_EXISTS("파일이 존재하지 않습니다!"),
     FILE_UPLOAD_LIMIT("업로드 가능한 파일은 10개까지입니다!"),
-    UNAUTHORIZED_ACCESS("접근권한을 가지고 있지 않습니다!");
+    UNAUTHORIZED_ACCESS("접근권한을 가지고 있지 않습니다!"),
+    MEMBER_ALREADY_LIKED_BOARD("이미 좋아요한 게시글입니다!");
 
     private final String message;
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardLikeServiceImpl;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberAlreadyLikedBoardException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import java.util.Arrays;
@@ -88,6 +89,22 @@ class BoardLikeControllerTest {
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
                     .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자가 이미 관심게시글로 등록한 게시글임")
+        void addBoardLikeFailMemberAlreadyLikedBoard() throws Exception {
+            // given
+            // when
+            doThrow(MemberAlreadyLikedBoardException.class).when(boardLikeService).add(anyLong(), anyLong());
+
+            // then
+            mvc.perform(post("/board/like/{id}", 1L))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.status", equalTo(400)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(MEMBER_ALREADY_LIKED_BOARD.getMessage())))
                     .andExpect(jsonPath("$.data", equalTo(null)));
         }
     }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepositoryTest.java
@@ -4,6 +4,9 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardLike;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,6 +23,9 @@ class BoardLikeRepositoryTest {
     @Autowired
     private BoardRepository boardRepository;
 
+    @Autowired
+    private MemberRepository memberRepository;
+
     @Test
     @DisplayName("쿼리메소드 countByBoard() 테스트")
     void countByBoard() {
@@ -33,5 +39,27 @@ class BoardLikeRepositoryTest {
 
         // then
         assertThat(result).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("쿼리메소드 findByBoardAndMember() 테스트")
+    void findByBoardAndMember() {
+        // given
+        Board board = boardRepository.save(new Board());
+        Member member = memberRepository.save(new Member());
+        BoardLike boardLike = BoardLike.builder()
+                .board(board)
+                .member(member)
+                .build();
+
+        boardLikeRepository.save(boardLike);
+
+        // when
+        Optional<BoardLike> savedBoardLike = boardLikeRepository.findByBoardAndMember(board, member);
+
+        // then
+        assertThat(savedBoardLike.isPresent()).isTrue();
+        assertThat(savedBoardLike.get().getBoard()).isEqualTo(board);
+        assertThat(savedBoardLike.get().getMember()).isEqualTo(member);
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
@@ -15,6 +15,7 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardLikeServiceImpl;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberAlreadyLikedBoardException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
@@ -107,6 +108,27 @@ class BoardLikeServiceTest {
             assertThatThrownBy(() -> boardLikeService.add(boardId, memberId))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자가 이미 관심게시글로 등록한 게시글임")
+        void addBoardLikeFailMemberAlreadyLikedBoard() {
+            // given
+            Long boardId = 1L;
+            Long memberId = 1L;
+            Board mockBoard = mock(Board.class);
+            Member mockMember = mock(Member.class);
+            BoardLike mockBoardLike = mock(BoardLike.class);
+
+            when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
+            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(boardLikeRepository.findByBoardAndMember(any(), any())).thenReturn(Optional.of(mockBoardLike));
+
+            // when
+            // then
+            assertThatThrownBy(() -> boardLikeService.add(boardId, memberId))
+                    .isInstanceOf(MemberAlreadyLikedBoardException.class)
+                    .hasMessage(MEMBER_ALREADY_LIKED_BOARD.getMessage());
         }
     }
 


### PR DESCRIPTION
### 구현 기능
같은 사용자가 같은 게시글에 대해서 계속 관심게시글로 등록할 수 있는 버스 해결.

### 관련 이슈
resovled #50 