### PR TITLE
검색시 검색횟수 갱신 및 사용자의 최근 검색어 목록 추가 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -5,6 +5,7 @@ import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
@@ -23,6 +24,7 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -71,15 +73,7 @@ public class BoardController {
     }
 
     @GetMapping
-    public ResponseEntity<?> search(BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
-        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(null, searchRequestDto, pageable);
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
-    }
-
-    @GetMapping("/status")
-    public ResponseEntity<?> searchBoardsByStatus(BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
+    public ResponseEntity<?> search(@RequestBody BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
         // TODO memberId -> JWT.getMemberId()
         Long memberId = 1L;
         PageResponseDto<BoardSearchResponseDto> boards = boardService.search(memberId, searchRequestDto, pageable);
@@ -88,11 +82,11 @@ public class BoardController {
                 .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
     }
 
-    @GetMapping("/hidden")
-    public ResponseEntity<?> searchHiddenBoards(Boolean hide, @PageableDefault(size = 10) Pageable pageable) {
+    @GetMapping("/my")
+    public ResponseEntity<?> searchMyBoards(@RequestBody MyBoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
         // TODO memberId -> JWT.getMemberId()
         Long memberId = 1L;
-        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(memberId, BoardSearchRequestDto.builder().hide(hide).build(), pageable);
+        PageResponseDto<BoardSearchResponseDto> boards = boardService.searchMyBoards(memberId, searchRequestDto, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardRequestDto.java
@@ -91,6 +91,15 @@ public class BoardRequestDto {
         private Integer minPrice;
         private Integer maxPrice;
         private SearchOrder order;
+    }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MyBoardSearchRequestDto {
         private Status status;
         private Boolean hide;
     }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.carrot.carrotmarketclonecoding.board.repository;
 
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import org.springframework.data.domain.Page;
@@ -10,4 +11,6 @@ public interface BoardRepositoryCustom {
     Page<BoardSearchResponseDto> findAllByMemberAndSearchRequestDto(Member member, BoardSearchRequestDto searchRequestDto, Pageable pageable);
 
     Page<BoardSearchResponseDto> searchMemberLikedBoards(Member member, Pageable pageable);
+
+    Page<BoardSearchResponseDto> findAllByStatusOrHide(Member member, MyBoardSearchRequestDto searchRequestDto, Pageable pageable);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.carrot.carrotmarketclonecoding.board.service;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
@@ -16,6 +17,8 @@ public interface BoardService {
     BoardDetailResponseDto tmpBoardDetail(Long memberId);
 
     PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable);
+
+    PageResponseDto<BoardSearchResponseDto> searchMyBoards(Long memberId, MyBoardSearchRequestDto searchRequestDto, Pageable pageable);
 
     void update(BoardUpdateRequestDto updateRequestDto, Long boardId, Long memberId);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordService.java
@@ -1,0 +1,47 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SearchKeywordService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String SEARCH_RANK_KEY = "search:rank";
+    private static final String SEARCH_RECENT_KEY = "search:recent:";
+    private static final int MAX_RECENT_SEARCHES = 20;
+
+    public void addSearchRank(String keyword) {
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, keyword, 1);
+    }
+
+    public Set<String> getTopSearchRank() {
+        return redisTemplate.opsForZSet().reverseRange(SEARCH_RANK_KEY, 0, 9);
+    }
+
+    public void addMemberSearchKeywords(Long memberId, String keyword) {
+        String key = SEARCH_RECENT_KEY + memberId;
+
+        ListOperations<String, String> listOperations = redisTemplate.opsForList();
+        listOperations.remove(key, 1, keyword);
+        listOperations.rightPush(key, keyword);
+
+        if (listOperations.size(key) > MAX_RECENT_SEARCHES) {
+            listOperations.leftPop(key);
+        }
+    }
+
+    public List<String> getRecentSearches(Long memberId) {
+        String key = SEARCH_RECENT_KEY + memberId;
+        return redisTemplate.opsForList().range(key, 0, -1);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -6,6 +6,7 @@ import com.carrot.carrotmarketclonecoding.board.domain.Category;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
@@ -13,6 +14,7 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepositor
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
+import com.carrot.carrotmarketclonecoding.board.service.SearchService;
 import com.carrot.carrotmarketclonecoding.board.service.VisitService;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
@@ -24,10 +26,12 @@ import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -39,6 +43,7 @@ public class BoardServiceImpl implements BoardService {
     private final BoardLikeRepository boardLikeRepository;
     private final VisitService visitService;
     private final BoardPictureService boardPictureService;
+    private final SearchService searchService;
 
     @Override
     public Long register(BoardRegisterRequestDto registerRequestDto, Long memberId, boolean tmp) {
@@ -83,11 +88,17 @@ public class BoardServiceImpl implements BoardService {
     @Override
     @Transactional(readOnly = true)
     public PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable) {
-        Member member = null;
-        if (memberId != null) {
-            member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        }
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        searchService.addMemberSearchKeywords(memberId, searchRequestDto.getKeyword());
+        searchService.addSearchRank(searchRequestDto.getKeyword());
         return new PageResponseDto<>(boardRepository.findAllByMemberAndSearchRequestDto(member, searchRequestDto, pageable));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public PageResponseDto<BoardSearchResponseDto> searchMyBoards(Long memberId, MyBoardSearchRequestDto searchRequestDto, Pageable pageable) {
+        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        return new PageResponseDto<>(boardRepository.findAllByStatusOrHide(member, searchRequestDto, pageable));
     }
 
     @Override

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -14,7 +14,7 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepositor
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
-import com.carrot.carrotmarketclonecoding.board.service.SearchService;
+import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordService;
 import com.carrot.carrotmarketclonecoding.board.service.VisitService;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
@@ -43,7 +43,7 @@ public class BoardServiceImpl implements BoardService {
     private final BoardLikeRepository boardLikeRepository;
     private final VisitService visitService;
     private final BoardPictureService boardPictureService;
-    private final SearchService searchService;
+    private final SearchKeywordService searchKeywordService;
 
     @Override
     public Long register(BoardRegisterRequestDto registerRequestDto, Long memberId, boolean tmp) {
@@ -89,8 +89,8 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-        searchService.addMemberSearchKeywords(memberId, searchRequestDto.getKeyword());
-        searchService.addSearchRank(searchRequestDto.getKeyword());
+        searchKeywordService.addMemberSearchKeywords(memberId, searchRequestDto.getKeyword());
+        searchKeywordService.addSearchRank(searchRequestDto.getKeyword());
         return new PageResponseDto<>(boardRepository.findAllByMemberAndSearchRequestDto(member, searchRequestDto, pageable));
     }
 

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/BoardTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/BoardTestDisplayNames.java
@@ -1,0 +1,74 @@
+package com.carrot.carrotmarketclonecoding.board;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BoardTestDisplayNames {
+    BOARD_REGISTER_SERVICE_TEST(MESSAGE.BOARD_REGISTER_SERVICE_TEST),
+    BOARD_DETAIL_SERVICE_TEST(MESSAGE.BOARD_DETAIL_SERVICE_TEST),
+    BOARD_SEARCH_SERVICE_TEST(MESSAGE.BOARD_SEARCH_SERVICE_TEST),
+    BOARD_MY_DETAIL_SERVICE_TEST(MESSAGE.BOARD_MY_DETAIL_SERVICE_TEST),
+    BOARD_UPDATE_SERVICE_TEST(MESSAGE.BOARD_UPDATE_SERVICE_TEST),
+    BOARD_DELETE_SERVICE_TEST(MESSAGE.BOARD_DELETE_SERVICE_TEST),
+    BOARD_GET_TMP_SERVICE_TEST(MESSAGE.BOARD_GET_TMP_SERVICE_TEST),
+    BOARD_REGISTER_CONTROLLER_TEST(MESSAGE.BOARD_REGISTER_CONTROLLER_TEST),
+    BOARD_DETAIL_CONTROLLER_TEST(MESSAGE.BOARD_DETAIL_CONTROLLER_TEST),
+    BOARD_SEARCH_CONTROLLER_TEST(MESSAGE.BOARD_SEARCH_CONTROLLER_TEST),
+    BOARD_MY_DETAIL_CONTROLLER_TEST(MESSAGE.BOARD_MY_DETAIL_CONTROLLER_TEST),
+    BOARD_UPDATE_CONTROLLER_TEST(MESSAGE.BOARD_UPDATE_CONTROLLER_TEST),
+    BOARD_DELETE_CONTROLLER_TEST(MESSAGE.BOARD_DELETE_CONTROLLER_TEST),
+    BOARD_GET_TMP_CONTROLLER_TEST(MESSAGE.BOARD_GET_TMP_CONTROLLER_TEST),
+    SUCCESS(MESSAGE.SUCCESS),
+    SUCCESS_REGISTER_TMP_BOARD(MESSAGE.SUCCESS_REGISTER_TMP_BOARD),
+    SUCCESS_INCLUDE_INCREASE_VISIT(MESSAGE.SUCCESS_INCLUDE_INCREASE_VISIT),
+    SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS(MESSAGE.SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS),
+    SUCCESS_DELETE_OLD_TMP_BOARDS(MESSAGE.SUCCESS_DELETE_OLD_TMP_BOARDS),
+    SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP(MESSAGE.SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP),
+    SUCCESS_NO_TMP_BOARDS(MESSAGE.SUCCESS_NO_TMP_BOARDS),
+    FAIL_INPUT_NOT_VALID(MESSAGE.FAIL_INPUT_NOT_VALID),
+    FAIL_FILE_COUNT_OVER_10(MESSAGE.FAIL_FILE_COUNT_OVER_10),
+    FAIL_WRITER_NOT_FOUND(MESSAGE.FAIL_WRITER_NOT_FOUND),
+    FAIL_MEMBER_NOT_FOUND(MESSAGE.FAIL_MEMBER_NOT_FOUND),
+    FAIL_CATEGORY_NOT_FOUND(MESSAGE.FAIL_CATEGORY_NOT_FOUND),
+    FAIL_BOARD_NOT_FOUND(MESSAGE.FAIL_BOARD_NOT_FOUND),
+    FAIL_MEMBER_IS_NOT_WRITER(MESSAGE.FAIL_MEMBER_IS_NOT_WRITER),
+    FAIL_NEW_PICTURES_COUNT_OVER_10(MESSAGE.FAIL_NEW_PICTURES_COUNT_OVER_10);
+
+    private final String message;
+
+    public static class MESSAGE {
+        public static final String BOARD_REGISTER_SERVICE_TEST = "게시글 작성 서비스 테스트";
+        public static final String BOARD_DETAIL_SERVICE_TEST = "게시글 조회 서비스 테스트";
+        public static final String BOARD_SEARCH_SERVICE_TEST = "게시글 검색 서비스 테스트";
+        public static final String BOARD_MY_DETAIL_SERVICE_TEST = "내 게시글 조회 서비스 테스트";
+        public static final String BOARD_UPDATE_SERVICE_TEST = "게시글 수정 서비스 테스트";
+        public static final String BOARD_DELETE_SERVICE_TEST = "게시글 삭제 서비스 테스트";
+        public static final String BOARD_GET_TMP_SERVICE_TEST = "임시 게시글 조회 서비스 테스트";
+
+        public static final String BOARD_REGISTER_CONTROLLER_TEST = "게시글 작성 컨트롤러 테스트";
+        public static final String BOARD_DETAIL_CONTROLLER_TEST = "게시글 조회 컨트롤러 테스트";
+        public static final String BOARD_SEARCH_CONTROLLER_TEST = "게시글 검색 컨트롤러 테스트";
+        public static final String BOARD_MY_DETAIL_CONTROLLER_TEST = "내 게시글 조회 컨트롤러 테스트";
+        public static final String BOARD_UPDATE_CONTROLLER_TEST = "게시글 수정 컨트롤러 테스트";
+        public static final String BOARD_DELETE_CONTROLLER_TEST = "게시글 삭제 컨트롤러 테스트";
+        public static final String BOARD_GET_TMP_CONTROLLER_TEST = "임시저장된 게시글 조회 컨트롤러 테스트";
+
+        public static final String SUCCESS = "성공";
+        public static final String SUCCESS_INCLUDE_INCREASE_VISIT = "성공 - 조회수 증가 포함";
+        public static final String SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS = "성공 - 24시간내에 재조회할경우 조회수 증가 x";
+        public static final String SUCCESS_DELETE_OLD_TMP_BOARDS = "성공 - 임시저장한 게시글을 수정한경우 이전 임시저장게시글 모두 삭제";
+        public static final String SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP = "성공 - 임시저장한 게시글이 아닐경우 이전의 임시저장한 게시글을 삭제x";
+        public static final String SUCCESS_NO_TMP_BOARDS = "성공 - 임싯저장 게시글이 존재하지 않음";
+        public static final String SUCCESS_REGISTER_TMP_BOARD = "성공 - 임시게시글 저장";
+        public static final String FAIL_INPUT_NOT_VALID = "실패 - 유효성 검사 실패";
+        public static final String FAIL_FILE_COUNT_OVER_10 = "실패 - 업로드 요청한 파일의 개수가 10개 초과";
+        public static final String FAIL_WRITER_NOT_FOUND = "실패 - 존재하지 않는 작성자";
+        public static final String FAIL_MEMBER_NOT_FOUND = "실패 - 존재하지 않는 사용자";
+        public static final String FAIL_CATEGORY_NOT_FOUND = "실패 - 존재하지 않는 카테고리";
+        public static final String FAIL_BOARD_NOT_FOUND = "실패 - 존재하지 않는 게시판";
+        public static final String FAIL_MEMBER_IS_NOT_WRITER = "실패 - 작성자와 사용자가 일치하지 않음";
+        public static final String FAIL_NEW_PICTURES_COUNT_OVER_10 = "실패 - 새로 첨부하는 사진의 개수가 10개를 넘음";
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordServiceTest.java
@@ -1,0 +1,129 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrot.carrotmarketclonecoding.RedisContainerConfig;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataRedisTest
+@ExtendWith(RedisContainerConfig.class)
+class SearchKeywordServiceTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String SEARCH_RANK_KEY = "search:rank";
+    private static final String SEARCH_RECENT_KEY = "search:recent:";
+    private static final int MAX_RECENT_SEARCHES = 20;
+
+    @AfterEach
+    void rollBack() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("인기검색어 - 검색어 검색 횟수 증가")
+    void testAddSearchRank() {
+        // given
+        String keyword = "keyword";
+
+        // when
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, keyword, 1);
+        Set<TypedTuple<String>> result = redisTemplate.opsForZSet().rangeWithScores(SEARCH_RANK_KEY, 0, -1);
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("인기검색어 - 인기검색어목록 조회")
+    void testGetTopSearchRank() {
+        // given
+        // when
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, "keyboard", 1);
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, "keyboard", 1);
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, "mac", 1);
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, "mac book", 1);
+
+        Set<String> result = redisTemplate.opsForZSet().reverseRange(SEARCH_RANK_KEY, 0, 9);
+
+        // then
+        assertThat(result.size()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("최근검색어 - 사용자의 최근검색어 추가")
+    void testAddMemberSearchKeywords() {
+        // given
+        String key = SEARCH_RECENT_KEY + 1L;
+        String keyword = "keyword";
+
+        // when
+        ListOperations<String, String> listOperations = redisTemplate.opsForList();
+        listOperations.remove(key, 1, keyword);
+        listOperations.rightPush(key, keyword);
+
+        // then
+        String result = listOperations.leftPop(key);
+        assertThat(result).isEqualTo(keyword);
+    }
+
+    @Test
+    @DisplayName("최근검색어 - 사용자의 최근검색어 개수가 20개가 넘어갈경우 오래된 검색어 제거")
+    void testAddMemberSearchKeywordsRemoveOldKeyword() {
+        // given
+        Long memberId = 1L;
+        String key = SEARCH_RECENT_KEY + memberId;
+        String keyword = "keyword";
+
+        // when
+        ListOperations<String, String> listOperations = redisTemplate.opsForList();
+        for (int i = 1; i <= 22; i++) {
+            String keywordToSave = keyword + i;
+            listOperations.remove(key, 1, keywordToSave);
+            listOperations.rightPush(key, keywordToSave);
+            if (listOperations.size(key) > MAX_RECENT_SEARCHES) {
+                listOperations.leftPop(key);
+            }
+        }
+
+        // then
+        Long size = listOperations.size(key);
+        String result = listOperations.leftPop(key);
+        assertThat(size).isEqualTo(20);
+        assertThat(result).isEqualTo("keyword3");
+    }
+
+    @Test
+    @DisplayName("최근검색어 - 사용자의 최근검색어 목록 조회")
+    void testGetRecentSearches() {
+        // given
+        Long memberId = 1L;
+        String key = SEARCH_RECENT_KEY + memberId;
+
+        // when
+        ListOperations<String, String> listOperations = redisTemplate.opsForList();
+        listOperations.rightPush(key, "keyword1");
+        listOperations.rightPush(key, "keyword2");
+        listOperations.rightPush(key, "keyword3");
+
+        // then
+        List<String> result = listOperations.range(key, 0, -1);
+        assertThat(result.size()).isEqualTo(3);
+    }
+}


### PR DESCRIPTION
## 구현 기능
기존 검색기능에 회원이 검색어를 검색할시 해당 검색어의 검색 횟수를 +1.
동시에 해당 검색어를 사용자의 최근 검색어 목록에 추가.
최근 검색어는 20개까지 유지(20개가 넘어갈경우 오래된 최근 검색어는 삭제)

## 관련 이슈
resolved #65 