### PR TITLE
게시글 삭제시 해당 게시글을 좋아요한 내역도 같이 삭제

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -75,7 +75,7 @@ public class BoardController {
     @GetMapping
     public ResponseEntity<?> search(@RequestBody BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
         // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
+        Long memberId = null;
         PageResponseDto<BoardSearchResponseDto> boards = boardService.search(memberId, searchRequestDto, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/domain/Board.java
@@ -6,7 +6,6 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegiste
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
 import com.carrot.carrotmarketclonecoding.common.BaseEntity;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -66,9 +65,15 @@ public class Board extends BaseEntity {
 
     private Boolean tmp;
 
+    @Builder.Default
     @BatchSize(size = 1000)
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "board")
     private List<BoardPicture> boardPictures = new ArrayList<>();
+
+    @Builder.Default
+    @BatchSize(size = 1000)
+    @OneToMany(mappedBy = "board")
+    private List<BoardLike> boardLikes = new ArrayList<>();
 
     public void increaseVisit() {
         this.visit += 1;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
@@ -36,6 +36,8 @@ public class BoardResponseDto {
         private Boolean suggest;
         private LocalDateTime createDate;
         private String description;
+
+        @Builder.Default
         private List<PictureResponseDto> pictures = new ArrayList<>();
         private int chat;
         private int like;
@@ -97,7 +99,7 @@ public class BoardResponseDto {
         private int price;
         private int like;
 
-        public static BoardSearchResponseDto getSearchResult(Board board, int like) {
+        public static BoardSearchResponseDto getSearchResult(Board board) {
             return BoardSearchResponseDto.builder()
                     .id(board.getId())
                     .pictureUrl(board.getBoardPictures() != null && board.getBoardPictures().size() > 0 ? board.getBoardPictures().get(0).getPictureUrl() : null)
@@ -105,7 +107,7 @@ public class BoardResponseDto {
                     .place(board.getPlace())
                     .createDate(board.getCreateDate())
                     .price(board.getPrice())
-                    .like(like)
+                    .like(board.getBoardLikes().size())
                     .build();
         }
     }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
@@ -5,8 +5,14 @@ import com.carrot.carrotmarketclonecoding.board.domain.BoardLike;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     int countByBoard(Board board);
     Optional<BoardLike> findByBoardAndMember(Board board, Member member);
+
+    @Modifying
+    @Query("DELETE FROM BoardLike b WHERE b.board.id = :boardId")
+    void deleteAllByBoardId(Long boardId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardPictureRepository.java
@@ -4,7 +4,13 @@ import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardPictureRepository extends JpaRepository<BoardPicture, Long> {
     List<BoardPicture> findByBoard(Board board);
+
+    @Modifying
+    @Query("DELETE FROM BoardPicture bp WHERE bp.board.id = :boardId")
+    void deleteAllByBoardId(Long boardId);
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -3,15 +3,8 @@ package com.carrot.carrotmarketclonecoding.board.service;
 import static com.carrot.carrotmarketclonecoding.board.BoardTestDisplayNames.MESSAGE.*;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
@@ -233,9 +226,7 @@ class BoardServiceTest {
                     BoardPicture.builder().id(2L).build());
             Board mockBoard = createMockBoard(boardId, memberId, mockPictures);
 
-
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
-            when(boardPictureRepository.findByBoard(any())).thenReturn(mockPictures);
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
             when(visitService.increaseVisit(anyString(), anyString())).thenReturn(true);
 
@@ -268,7 +259,6 @@ class BoardServiceTest {
             Board mockBoard = createMockBoard(boardId, memberId, mockPictures);
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
-            when(boardPictureRepository.findByBoard(any())).thenReturn(mockPictures);
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
             when(visitService.increaseVisit(anyString(), anyString())).thenReturn(false);
 
@@ -603,6 +593,8 @@ class BoardServiceTest {
             boardService.delete(boardId, memberId);
 
             // then
+            verify(boardLikeRepository).deleteAllByBoardId(boardId);
+            verify(boardPictureRepository).deleteAllByBoardId(boardId);
             verify(boardRepository).delete(mockBoard);
         }
 


### PR DESCRIPTION
## 구현 기능
- [x] Board 엔티티와 BoardLike 엔티티를 일대다 양방향 관계로 수정.
- [x] BoardLike 참조필드에 배치사이즈(1000) 적용. (한번에 1000개까지 조회함으로서 성능 향상)
- [x] 게시글 삭제시 cascade가 아닌 각각의 repository를 사용하여 delete문이 여러번 나가지 않도록 수정.
- [x] Board <-> BaordLike 일대다 양방향 관계로 수정됨으로써 QueryDsl의 join문 제거. 
- [x] 비회원 상태에서도 게시글 검색이 가능하도록 수정. 


## 관련 이슈
resolved #75 