### PR TITLE
카카오 소셜 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // security
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+    implementation 'com.auth0:java-jwt:4.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
@@ -1,0 +1,40 @@
+package com.carrot.carrotmarketclonecoding.auth.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.RECREATE_TOKENS_SUCCESS;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
+import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+public class KakaoLoginController {
+
+    private final LoginService loginService;
+
+    @GetMapping("/callback")
+    public ResponseEntity<?> callback(@RequestParam("code") String code) {
+        TokenDto tokens = loginService.login(code);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, LOGIN_SUCCESS.getMessage(), tokens));
+    }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<?> refresh(@RequestHeader("Authorization") String refreshToken) {
+        TokenDto tokens = loginService.refresh(refreshToken);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, RECREATE_TOKENS_SUCCESS.getMessage(), tokens));
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/JwtVO.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/JwtVO.java
@@ -1,0 +1,7 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+public interface JwtVO {
+    String TOKEN_PREFIX = "Bearer ";
+    String HEADER = "Authorization";
+    String JWT_EXCEPTION_ATTRIBUTE = "jwt_exception";
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/KakaoTokenResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/KakaoTokenResponseDto.java
@@ -1,0 +1,35 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDto {
+
+    @JsonProperty("token_type")
+    public String tokenType;
+
+    @JsonProperty("access_token")
+    public String accessToken;
+
+    @JsonProperty("id_token")
+    public String idToken;
+
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/KakaoUserInfoResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/KakaoUserInfoResponseDto.java
@@ -1,0 +1,23 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDto {
+
+    @JsonProperty("id")
+    public Long id;
+
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/LoginRespDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/LoginRespDto.java
@@ -1,0 +1,20 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+public class LoginRespDto {
+    private Long authId;
+    private Role role;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/LoginUser.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/LoginUser.java
@@ -1,0 +1,52 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import java.util.ArrayList;
+import java.util.Collection;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+@RequiredArgsConstructor
+public class LoginUser implements UserDetails {
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(() -> "ROLE_" + member.getRole());
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getAuthId().toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/TokenDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/dto/TokenDto.java
@@ -1,0 +1,14 @@
+package com.carrot.carrotmarketclonecoding.auth.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenDto {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.carrot.carrotmarketclonecoding.auth.exception;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.util.LoginResponseUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        if (request.getAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE) != null) {
+            LoginResponseUtil.fail(response, request.getAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE).toString(), HttpStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/filter/JwtAuthorizationFilter.java
@@ -1,0 +1,62 @@
+package com.carrot.carrotmarketclonecoding.auth.filter;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_EXPIRED_MESSAGE;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_NOT_EXISTS;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_NOT_VALID;
+
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+@Slf4j
+public class JwtAuthorizationFilter extends BasicAuthenticationFilter {
+
+    private final JwtUtil jwtUtil;
+
+    public JwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        super(authenticationManager);
+        this.jwtUtil = jwtUtil;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        try {
+            if (isHeaderVerify(request, response)) {
+                String token = request.getHeader(JwtVO.HEADER);
+                LoginUser loginUser = jwtUtil.verify(token);
+
+                Authentication authentication = new UsernamePasswordAuthenticationToken(loginUser, null, loginUser.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } else {
+                request.setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_NOT_EXISTS.getMessage());
+            }
+        } catch (TokenExpiredException e) {
+            request.setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_EXPIRED_MESSAGE.getMessage());
+        } catch (SignatureVerificationException e) {
+            request.setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_NOT_VALID.getMessage());
+        }
+        chain.doFilter(request, response);
+    }
+
+    private boolean isHeaderVerify(HttpServletRequest request, HttpServletResponse response) {
+        String token = request.getHeader(JwtVO.HEADER);
+        if (token == null || !token.startsWith(JwtVO.TOKEN_PREFIX)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoService.java
@@ -1,0 +1,124 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoTokenNotExistsException;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoUserInfoNotExistsException;
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoTokenResponseDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Value("${kakao.client_id}")
+    private String clientId;
+
+    private static final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com/oauth/token";
+    private static final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com/v2/user/me";
+    private static final String KAKAO_REQUEST_HEADER = "Bearer ";
+    private static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
+    private static final String PROPERTY_NICKNAME = "nickname";
+    private static final String PROPERTY_PROFILE_IMAGE = "profile_image";
+    private static final String PARAM_GRANT_TYPE = "grant_type";
+    private static final String PARAM_CLIENT_ID = "client_id";
+    private static final String PARAM_CODE = "code";
+    private static final String GRANT_TYPE_VALUE = "authorization_code";
+
+    private final MemberRepository memberRepository;
+    private final RestTemplate restTemplate;
+
+    public String getAccessToken(String code) {
+        String url = UriComponentsBuilder.fromHttpUrl(KAUTH_TOKEN_URL_HOST)
+                .queryParam(PARAM_GRANT_TYPE, GRANT_TYPE_VALUE)
+                .queryParam(PARAM_CLIENT_ID, clientId)
+                .queryParam(PARAM_CODE, code)
+                .toUriString();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<KakaoTokenResponseDto> responseEntity = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                entity,
+                KakaoTokenResponseDto.class
+        );
+
+        KakaoTokenResponseDto kakaoTokenResponseDto = responseEntity.getBody();
+        if (kakaoTokenResponseDto == null) {
+            throw new KakaoTokenNotExistsException();
+        }
+
+        log.debug(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
+        log.debug(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
+        log.debug(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
+        log.debug(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
+
+        return kakaoTokenResponseDto.getAccessToken();
+    }
+
+    public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, KAKAO_REQUEST_HEADER + accessToken);
+        headers.set(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<KakaoUserInfoResponseDto> responseEntity = restTemplate.exchange(
+                KAUTH_USER_URL_HOST,
+                HttpMethod.GET,
+                entity,
+                KakaoUserInfoResponseDto.class
+        );
+
+        KakaoUserInfoResponseDto userInfo = responseEntity.getBody();
+        if (userInfo == null) {
+            throw new KakaoUserInfoNotExistsException();
+        }
+
+        log.debug("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
+        log.debug("[ Kakao Service ] NickName ---> {} ", userInfo.getProperties().get(PROPERTY_NICKNAME));
+        log.debug("[ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.getProperties().get(PROPERTY_PROFILE_IMAGE));
+
+        return userInfo;
+    }
+
+    public LoginRespDto join(KakaoUserInfoResponseDto userInfo) {
+        Optional<Member> optionalMember = memberRepository.findByAuthId(userInfo.getId());
+        Member member = null;
+
+        if (optionalMember.isPresent()) {
+            member = optionalMember.get();
+        } else {
+            member = memberRepository.save(Member.builder()
+                    .authId(userInfo.getId())
+                    .nickname(userInfo.getProperties().get(PROPERTY_NICKNAME))
+                    .profileUrl(userInfo.getProperties().get(PROPERTY_PROFILE_IMAGE))
+                    .town(null)
+                    .withdraw(false)
+                    .isTownAuthenticated(false)
+                    .role(Role.USER)
+                    .build());
+        }
+
+        return LoginRespDto.builder()
+                .authId(member.getAuthId())
+                .role(member.getRole())
+                .build();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/LoginService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/LoginService.java
@@ -1,0 +1,59 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
+import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.common.exception.RefreshTokenNotMatchException;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class LoginService {
+
+    private final JwtUtil jwtUtil;
+    private final KakaoService kakaoService;
+    private final RefreshTokenRedisService redisService;
+
+    public TokenDto login(String code) {
+        String kakaoAccessToken = kakaoService.getAccessToken(code);
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(kakaoAccessToken);
+        LoginRespDto loginResponse = kakaoService.join(userInfo);
+
+        Long authId = loginResponse.getAuthId();
+        Role role = loginResponse.getRole();
+        String accessToken = jwtUtil.createAccessToken(authId, role);
+        String refreshToken = jwtUtil.createRefreshToken(authId, role);
+        redisService.saveRefreshToken(authId, refreshToken);
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public TokenDto refresh(String refreshToken) {
+        LoginUser user = jwtUtil.verify(refreshToken);
+        Long authId = user.getMember().getAuthId();
+        Role role = user.getMember().getRole();
+
+        String savedRefreshToken = redisService.getRefreshToken(authId);
+        if (!savedRefreshToken.equals(refreshToken)) {
+            throw new RefreshTokenNotMatchException();
+        }
+
+        redisService.deleteRefreshToken(authId);
+
+        String accessToken = jwtUtil.createAccessToken(authId, role);
+        String newRefreshToken = jwtUtil.createRefreshToken(authId, role);
+        redisService.saveRefreshToken(authId, newRefreshToken);
+
+        return TokenDto.builder()
+                .accessToken(accessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/RefreshTokenRedisService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/RefreshTokenRedisService.java
@@ -1,0 +1,36 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh_expiration_time}")
+    private Long REFRESH_EXPIRATION_TIME;
+
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
+
+    public void saveRefreshToken(Long authId, String refreshToken) {
+        redisTemplate.opsForValue().set(
+                REFRESH_TOKEN_KEY_PREFIX + authId,
+                refreshToken,
+                REFRESH_EXPIRATION_TIME,
+                TimeUnit.MILLISECONDS
+        );
+    }
+
+    public String getRefreshToken(Long authId) {
+        return redisTemplate.opsForValue().get(REFRESH_TOKEN_KEY_PREFIX + authId);
+    }
+
+    public void deleteRefreshToken(Long authId) {
+        redisTemplate.delete(REFRESH_TOKEN_KEY_PREFIX + authId);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/util/JwtUtil.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/util/JwtUtil.java
@@ -1,0 +1,60 @@
+package com.carrot.carrotmarketclonecoding.auth.util;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUtil {
+
+    @Value("${jwt.secret}")
+    private String SECRET;
+
+    @Value("${jwt.expiration_time}")
+    private int EXPIRATION_TIME;
+
+    @Value("${jwt.refresh_expiration_time}")
+    private long REFRESH_EXPIRATION_TIME;
+
+    private static final String SUBJECT = "token";
+    private static final String CLAIM_ID = "id";
+    private static final String CLAIM_ROLE = "role";
+
+    public String createAccessToken(Long authId, Role role) {
+        return create(authId, role, EXPIRATION_TIME);
+    }
+
+    public String createRefreshToken(Long authId, Role role) {
+        return create(authId, role, REFRESH_EXPIRATION_TIME);
+    }
+
+    private String create(Long authId, Role role, long expirationTime) {
+        String jwtToken = JWT.create()
+                .withSubject(SUBJECT)
+                .withExpiresAt(new Date(System.currentTimeMillis() + expirationTime))
+                .withClaim(CLAIM_ID, authId)
+                .withClaim(CLAIM_ROLE, role.name())
+                .sign(Algorithm.HMAC512(SECRET));
+        return JwtVO.TOKEN_PREFIX + jwtToken;
+    }
+
+    public LoginUser verify(String token) {
+        DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC512(SECRET))
+                .build()
+                .verify(token.replace(JwtVO.TOKEN_PREFIX, ""));
+
+        Member member = Member.builder()
+                .authId(decodedJWT.getClaim(CLAIM_ID).asLong())
+                .role(Role.valueOf(decodedJWT.getClaim(CLAIM_ROLE).asString()))
+                .build();
+
+        return new LoginUser(member);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/util/LoginResponseUtil.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/util/LoginResponseUtil.java
@@ -1,0 +1,41 @@
+package com.carrot.carrotmarketclonecoding.auth.util;
+
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
+
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Slf4j
+public class LoginResponseUtil {
+
+    public static void success(HttpServletResponse response, Object data) {
+        try {
+            ObjectMapper om = new ObjectMapper();
+            ResponseResult result = ResponseResult.success(HttpStatus.OK, LOGIN_SUCCESS.getMessage(), data);
+            String responseBody = om.writeValueAsString(result);
+
+            response.setContentType("application/json; charset=utf-8");
+            response.setStatus(200);
+            response.getWriter().println(responseBody);
+        } catch (Exception e) {
+            log.error("server parsing error");
+        }
+    }
+
+    public static void fail(HttpServletResponse response, String msg, HttpStatus httpStatus) {
+        try {
+            ObjectMapper om = new ObjectMapper();
+            ResponseResult result = ResponseResult.failed(httpStatus, msg, null);
+            String responseBody = om.writeValueAsString(result);
+
+            response.setContentType("application/json; charset=utf-8");
+            response.setStatus(httpStatus.value());
+            response.getWriter().println(responseBody);
+        } catch (Exception e) {
+            log.error("server parsing error");
+        }
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/KakaoTokenNotExistsException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/KakaoTokenNotExistsException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.KAKAO_TOKEN_NOT_EXISTS;
+
+import org.springframework.http.HttpStatus;
+
+public class KakaoTokenNotExistsException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return KAKAO_TOKEN_NOT_EXISTS.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/KakaoUserInfoNotExistsException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/KakaoUserInfoNotExistsException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.KAKAO_USER_INFO_NOT_EXISTS;
+
+import org.springframework.http.HttpStatus;
+
+public class KakaoUserInfoNotExistsException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.INTERNAL_SERVER_ERROR;
+    }
+
+    @Override
+    public String getMessage() {
+        return KAKAO_USER_INFO_NOT_EXISTS.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/RefreshTokenNotMatchException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/RefreshTokenNotMatchException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.REFRESH_TOKEN_NOT_MATCH;
+
+import org.springframework.http.HttpStatus;
+
+public class RefreshTokenNotMatchException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.UNAUTHORIZED;
+    }
+
+    @Override
+    public String getMessage() {
+        return REFRESH_TOKEN_NOT_MATCH.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -15,9 +15,19 @@ public enum FailedMessage {
     FILE_NOT_EXISTS("파일이 존재하지 않습니다!"),
     FILE_UPLOAD_LIMIT("업로드 가능한 파일은 10개까지입니다!"),
     UNAUTHORIZED_ACCESS("접근권한을 가지고 있지 않습니다!"),
+
     MEMBER_ALREADY_LIKED_BOARD("이미 관심게시글로 등록한 게시글입니다!"),
     MEMBER_WORD_OVER_LIMIT("자주쓰는문구의 개수는 30개를 초과할 수 없습니다!"),
-    WORD_NOT_FOUND("존재하지 않는 자주쓰는문구입니다!");
+    WORD_NOT_FOUND("존재하지 않는 자주쓰는문구입니다!"),
+
+    TOKEN_EXPIRED_MESSAGE("토큰이 만료되었습니다!"),
+    TOKEN_NOT_VALID("잘못된 토큰입니다!"),
+    FORBIDDEN("접근권한이 없습니다!"),
+    ACCESS_DENIED("로그인을 시도해주세요!"),
+    TOKEN_NOT_EXISTS("토큰이 존재하지 않습니다!"),
+    KAKAO_TOKEN_NOT_EXISTS("카카오로부터 받아온 토큰이 존재하지 않습니다!"),
+    KAKAO_USER_INFO_NOT_EXISTS("카카오로부터 받아온 사용자 정보가 존재하지 않습니다!"),
+    REFRESH_TOKEN_NOT_MATCH("리프레시 토큰이 일치하지 않습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -15,14 +15,20 @@ public enum SuccessMessage {
     ADD_BOARD_LIKE_SUCCESS("관심게시글 등록에 성공하였습니다!"),
     GET_MEMBER_LIKED_BOARDS_SUCCESS("관심 게시글 목록 조회에 성공하였습니다!"),
     SEARCH_BOARDS_SUCCESS("게시글 검색에 성공하였습니다!"),
+
     ADD_WORD_SUCCESS("자주쓰는문구 추가에 성공하였습니다!"),
     GET_MEMBER_WORDS("사용자의 자주쓰는문구 목록 조회에 성공하였습니다!"),
     UPDATE_WORD_SUCCESS("자주쓰는문구 수정에 성공하였습니다!"),
     REMOVE_WORD_SUCCESS("자주쓰는문구 삭제에 성공하였습니다!"),
+
     GET_TOP_RANK_SEARCH_KEYWORDS_SUCCESS("인기검색어 목록 조회에 성공하였습니다!"),
     GET_RECENT_SEARCH_KEYWORDS_SUCCESS("사용자의 최근 검색어 목록 조회에 성공하였습니다!"),
     REMOVE_RECENT_SEARCH_KEYWORD_SUCCESS("사용자의 최근 검색어 삭제에 성공하였습니다!"),
-    REMOVE_ALL_RECENT_SEARCH_KEYWORD_SUCCESS("사용자의 최근 검색어 전체 삭제에 성공하였습니다!");
+    REMOVE_ALL_RECENT_SEARCH_KEYWORD_SUCCESS("사용자의 최근 검색어 전체 삭제에 성공하였습니다!"),
+
+    LOGIN_SUCCESS("로그인에 성공하였습니다!"),
+    RECREATE_TOKENS_SUCCESS("토큰 재발급에 성공하였습니다!"),
+    LOGOUT_SUCCESS("로그아웃에 성공하였습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/AppConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.carrot.carrotmarketclonecoding.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
@@ -1,0 +1,85 @@
+package com.carrot.carrotmarketclonecoding.config;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FORBIDDEN;
+
+import com.carrot.carrotmarketclonecoding.auth.exception.CustomAuthenticationEntryPoint;
+import com.carrot.carrotmarketclonecoding.auth.filter.JwtAuthorizationFilter;
+import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.auth.util.LoginResponseUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Slf4j
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        return http.getSharedObject(AuthenticationManagerBuilder.class).build();
+    }
+
+    @Bean
+    public JwtAuthorizationFilter jwtAuthorizationFilter(AuthenticationManager authenticationManager, JwtUtil jwtUtil) {
+        return new JwtAuthorizationFilter(authenticationManager, jwtUtil);
+    }
+
+    @Bean
+    public AuthenticationEntryPoint authenticationEntryPoint() {
+        return new CustomAuthenticationEntryPoint();
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.headers(headers -> headers.frameOptions(FrameOptionsConfig::disable))
+            .cors(cors -> cors.configurationSource(configurationSource()))
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+            .csrf(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable);
+
+        http.addFilterBefore(jwtAuthorizationFilter(authenticationManager(http), new JwtUtil()), UsernamePasswordAuthenticationFilter.class);
+
+        http.exceptionHandling(exceptions -> exceptions
+                .authenticationEntryPoint(authenticationEntryPoint())
+                .accessDeniedHandler((request, response, accessDeniedException) -> {
+                    LoginResponseUtil.fail(response, FORBIDDEN.getMessage(), HttpStatus.FORBIDDEN);
+                }));
+
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/callback").permitAll()
+                .requestMatchers("/**").hasRole("USER")
+                .anyRequest().permitAll()
+        );
+
+        return http.build();
+    }
+
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedOriginPattern("*");
+        configuration.setAllowCredentials(true);
+
+        configuration.addExposedHeader("Authorization");
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
@@ -30,4 +30,6 @@ public class Member extends BaseEntity {
 
     @Enumerated(EnumType.STRING)
     private Role role;
+
+    private Long authId;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/repository/MemberRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/repository/MemberRepository.java
@@ -1,8 +1,9 @@
 package com.carrot.carrotmarketclonecoding.member.repository;
 
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Optional<Member> findByAuthId(Long authId);
 }

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -23,3 +23,7 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: blue_server
+
+kakao:
+  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+  redirect_uri: ENC(4+7kO9DaQ/b2Z2ebMbE7FQeoB2zHMoTIl2zwwtAqhRChhm5FOJtD7H9VYJYpEkrb)

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -23,3 +23,7 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: green_server
+
+kakao:
+  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+  redirect_uri: ENC(WvpjgCPvXXjgl/3C5daeUdnQ3rupSqr+l7JbiJTNgSortNlpDAo5e8Lu7e468DQM)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,6 @@ server:
   serverAddress: localhost
 
 serverName: localhost
+logging:
+  level:
+    com.carrot.carrotmarketclonecoding.auth: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,11 @@ s3:
     bucket: ENC(bNnIVCrcukSCn+ewUyarhrco4Y6GDvwgUwtPhk/CcpRwGd3waQzxCA==)
     accessKey: ENC(9I+FNe3mBV4sCcP+wF5Wo1E0tWxa5I6Qh2VpT0nHzuU=)
     secretKey: ENC(h6QDcliPmdblNeU+SluXUxywb09NhatUUjRI9RJoaUcFkCOSieRxNcp9SXjQ1gWjjFufORPP2BA=)
+
+kakao:
+  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+
+jwt:
+  secret: ENC(AZSMHtQVuCDzJNRt1ln9wKpeKm13cB6U9zIp23MOjjyBNIOqa+X7lMeAo8ki+bmW)
+  expiration_time: ENC(Lo7/s4mCESUiz0GI8/WYGA==)
+  refresh_expiration_time: ENC(k/35hOfhQC6TeZV6bs7KwhQo3I844ujZ)

--- a/src/main/resources/db/migration/V3__alter_table_members.sql
+++ b/src/main/resources/db/migration/V3__alter_table_members.sql
@@ -1,0 +1,1 @@
+ALTER TABLE members ADD COLUMN auth_id BIGINT;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginControllerTest.java
@@ -1,0 +1,101 @@
+package com.carrot.carrotmarketclonecoding.auth.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.REFRESH_TOKEN_NOT_MATCH;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.RECREATE_TOKENS_SUCCESS;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
+import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
+import com.carrot.carrotmarketclonecoding.common.exception.RefreshTokenNotMatchException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = KakaoLoginController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+class KakaoLoginControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private LoginService loginService;
+
+    @Test
+    @DisplayName("카카오 redirect-uri 테스트")
+    void callback() throws Exception {
+        // given
+        TokenDto tokens = TokenDto.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        // when
+        when(loginService.login(anyString())).thenReturn(tokens);
+
+        // then
+        mvc.perform(get("/callback")
+                .param("code", "code"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.result", equalTo(true)))
+                .andExpect(jsonPath("$.message", equalTo(LOGIN_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.accessToken", equalTo(tokens.getAccessToken())))
+                .andExpect(jsonPath("$.data.refreshToken", equalTo(tokens.getRefreshToken())));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 갱신 테스트")
+    void refresh() throws Exception {
+        // given
+        TokenDto tokens = TokenDto.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        // when
+        when(loginService.refresh(anyString())).thenReturn(tokens);
+
+        // then
+        mvc.perform(get("/refresh")
+                .header("Authorization", "oldRefreshToken"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.result", equalTo(true)))
+                .andExpect(jsonPath("$.message", equalTo(RECREATE_TOKENS_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data.accessToken", equalTo(tokens.getAccessToken())))
+                .andExpect(jsonPath("$.data.refreshToken", equalTo(tokens.getRefreshToken())));
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 갱신시 서버의 토큰과 일치하지 않을 경우 예외 발생 테스트")
+    void refreshFailRefreshTokenNotMatch() throws Exception {
+        // given
+        TokenDto tokens = TokenDto.builder()
+                .accessToken("accessToken")
+                .refreshToken("refreshToken")
+                .build();
+
+        // when
+        doThrow(RefreshTokenNotMatchException.class).when(loginService).refresh(anyString());
+
+        // then
+        mvc.perform(get("/refresh")
+                        .header("Authorization", "oldRefreshToken"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.status", equalTo(401)))
+                .andExpect(jsonPath("$.result", equalTo(false)))
+                .andExpect(jsonPath("$.message", equalTo(REFRESH_TOKEN_NOT_MATCH.getMessage())))
+                .andExpect(jsonPath("$.data", equalTo(null)));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/exception/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/exception/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,54 @@
+package com.carrot.carrotmarketclonecoding.auth.exception;
+
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.util.LoginResponseUtil;
+import com.carrot.carrotmarketclonecoding.common.response.FailedMessage;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationEntryPointTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private AuthenticationException authException;
+
+    @InjectMocks
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    @Test
+    @DisplayName("커스텀 AuthenticationEntryPoint 테스트")
+    void commence() throws Exception {
+        // given
+        String message = FailedMessage.TOKEN_NOT_VALID.getMessage();
+
+        when(request.getAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE)).thenReturn(message);
+
+        try (MockedStatic<LoginResponseUtil> mockedStatic = mockStatic(LoginResponseUtil.class)) {
+            // when
+            authenticationEntryPoint.commence(request, response, authException);
+
+            // then
+            mockedStatic.verify(() -> LoginResponseUtil.fail(eq(response), eq(message), eq(HttpStatus.UNAUTHORIZED)));
+        }
+    }
+
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/filter/JwtAuthorizationFilterTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/filter/JwtAuthorizationFilterTest.java
@@ -1,0 +1,136 @@
+package com.carrot.carrotmarketclonecoding.auth.filter;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_EXPIRED_MESSAGE;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_NOT_EXISTS;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TOKEN_NOT_VALID;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.AuthenticationManager;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthorizationFilterTest {
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private AuthenticationManager authenticationManager;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthorizationFilter jwtAuthorizationFilter;
+
+    @BeforeEach
+    public void setUp() {
+        request = mock(HttpServletRequest.class);
+        response = mock(HttpServletResponse.class);
+        filterChain = mock(FilterChain.class);
+    }
+
+    @Test
+    @DisplayName("토큰이 입력되지 않을 경우 통과 테스트")
+    public void doFilterTest() throws Exception {
+        // given
+        // when
+        jwtAuthorizationFilter.doFilter(request, response, filterChain);
+
+        // then
+        verify(filterChain, atLeastOnce()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("토큰이 존재하지 않을 경우 예외 발생 테스트")
+    void doFilterFailJwtVerification() throws ServletException, IOException {
+        // given
+        doReturn(null).when(request).getHeader(JwtVO.HEADER);
+
+        // when
+        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(request).setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_NOT_EXISTS.getMessage());
+        verify(filterChain, atLeastOnce()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("토큰이 만료되었을 경우 예외 발생 테스트")
+    void doFilterFail() throws ServletException, IOException {
+        // given
+        String accessToken = "Bearer AccessToken";
+        when(request.getHeader(anyString())).thenReturn(accessToken);
+        when(jwtUtil.verify(anyString())).thenThrow(TokenExpiredException.class);
+
+        // when
+        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(request).setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_EXPIRED_MESSAGE.getMessage());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효할경우 필터 통과 테스트")
+    void doFilterSuccessJwtVerification() throws ServletException, IOException {
+        // given
+        String accessToken = "Bearer validAccessToken";
+        LoginUser loginUser = new LoginUser(Member.builder().authId(1111L).role(Role.USER).build());
+
+        doReturn(accessToken).when(request).getHeader(JwtVO.HEADER);
+        when(jwtUtil.verify(anyString())).thenReturn(loginUser);
+
+        // when
+        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효하지 않을 경우 필터 통과 테스트")
+    void doFilterFailTokenNotValid() throws ServletException, IOException {
+        // given
+        String accessToken = "Bearer invalidAccessToken";
+
+        doReturn(accessToken).when(request).getHeader(JwtVO.HEADER);
+        when(jwtUtil.verify(anyString())).thenThrow(SignatureVerificationException.class);
+
+        // when
+        jwtAuthorizationFilter.doFilterInternal(request, response, filterChain);
+
+        // then
+        verify(request).setAttribute(JwtVO.JWT_EXCEPTION_ATTRIBUTE, TOKEN_NOT_VALID.getMessage());
+        verify(filterChain).doFilter(request, response);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoServiceTest.java
@@ -1,0 +1,165 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.KAKAO_TOKEN_NOT_EXISTS;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.KAKAO_USER_INFO_NOT_EXISTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoTokenResponseDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoTokenNotExistsException;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoUserInfoNotExistsException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.HashMap;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class KakaoServiceTest {
+
+    @InjectMocks
+    private KakaoService kakaoService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @Test
+    @DisplayName("카카오로 AccessToken 요청 테스트")
+    void getAccessToken() {
+        // given
+        KakaoTokenResponseDto kakaoTokenResponseDto = new KakaoTokenResponseDto();
+        kakaoTokenResponseDto.setTokenType("testTokenType");
+        kakaoTokenResponseDto.setAccessToken("testAccessToken");
+        kakaoTokenResponseDto.setIdToken("testIdToken");
+        kakaoTokenResponseDto.setExpiresIn(30000);
+        kakaoTokenResponseDto.setRefreshToken("testRefreshToken");
+        kakaoTokenResponseDto.setRefreshTokenExpiresIn(30000);
+        kakaoTokenResponseDto.setScope("scope");
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(KakaoTokenResponseDto.class)))
+                .thenReturn(ResponseEntity.ok(kakaoTokenResponseDto));
+
+        // when
+        String accessToken = kakaoService.getAccessToken("code");
+
+        // then
+        assertThat(accessToken).isEqualTo("testAccessToken");
+    }
+
+    @Test
+    @DisplayName("카카오로부터 AccessToken이 들어오지 않을 경우 예외 발생 테스트")
+    void getAccessTokenFailKakaoTokenNotExists() {
+        // given
+        when(restTemplate.exchange(anyString(), any(), any(), eq(KakaoTokenResponseDto.class)))
+                .thenReturn(ResponseEntity.ok(null));
+
+        // when
+        // then
+        assertThatThrownBy(() -> kakaoService.getAccessToken("code"))
+                .isInstanceOf(KakaoTokenNotExistsException.class)
+                .hasMessage(KAKAO_TOKEN_NOT_EXISTS.getMessage());
+    }
+
+    @Test
+    @DisplayName("카카오로 사용자정보 요청 테스트")
+    void getUserInfo() {
+        // given
+        KakaoUserInfoResponseDto kakaoUserInfoResponseDto = createMockKakaoUserInfoResponseDto();
+
+        when(restTemplate.exchange(anyString(), any(), any(), eq(KakaoUserInfoResponseDto.class)))
+                .thenReturn(ResponseEntity.ok(kakaoUserInfoResponseDto));
+
+        // when
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo("accessToken");
+
+        // then
+        assertThat(userInfo.getId()).isEqualTo(1111L);
+        assertThat(userInfo.getProperties().get("nickname")).isEqualTo("testNickName");
+        assertThat(userInfo.getProperties().get("profile_image")).isEqualTo("testProfileImage");
+    }
+
+    @Test
+    @DisplayName("카카오로부터 사용자정보가 들어오지 않을 경우 예외 발생 테스트")
+    void getUserInfoFailKakaoUserInfoNotExists() {
+        // given
+        when(restTemplate.exchange(anyString(), any(), any(), eq(KakaoUserInfoResponseDto.class)))
+                .thenReturn(ResponseEntity.ok(null));
+
+        // when
+        // then
+        assertThatThrownBy(() -> kakaoService.getUserInfo("accessToken"))
+                .isInstanceOf(KakaoUserInfoNotExistsException.class)
+                .hasMessage(KAKAO_USER_INFO_NOT_EXISTS.getMessage());
+    }
+
+    @Test
+    @DisplayName("존재하는 회원일경우 회원가입 테스트")
+    void joinWhenMemberAlreadyExists() {
+        // given
+        Long authId = 1111L;
+        Member member = Member.builder()
+                .authId(authId)
+                .role(Role.USER)
+                .build();
+
+        KakaoUserInfoResponseDto userInfo = createMockKakaoUserInfoResponseDto();
+
+        when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(member));
+
+        // when
+        LoginRespDto loginResponse = kakaoService.join(userInfo);
+
+        // then
+        assertThat(loginResponse.getAuthId()).isEqualTo(authId);
+        assertThat(loginResponse.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("존재하지않는 회원일경우 회원가입 테스트")
+    void joinWhenMemberNotExists() {
+        // given
+        Long authId = 1111L;
+
+        KakaoUserInfoResponseDto userInfo = createMockKakaoUserInfoResponseDto();
+
+        when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+        when(memberRepository.save(any())).thenReturn(Member.builder().authId(authId).role(Role.USER).build());
+
+        // when
+        LoginRespDto loginResponse = kakaoService.join(userInfo);
+
+        // then
+        assertThat(loginResponse.getAuthId()).isEqualTo(authId);
+        assertThat(loginResponse.getRole()).isEqualTo(Role.USER);
+    }
+
+    private KakaoUserInfoResponseDto createMockKakaoUserInfoResponseDto() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("nickname", "testNickName");
+        properties.put("profile_image", "testProfileImage");
+
+        KakaoUserInfoResponseDto userInfo = new KakaoUserInfoResponseDto();
+        userInfo.setId(1111L);
+        userInfo.setProperties(properties);
+
+        return userInfo;
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LoginServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LoginServiceTest.java
@@ -1,0 +1,121 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
+import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.common.exception.RefreshTokenNotMatchException;
+import com.carrot.carrotmarketclonecoding.common.response.FailedMessage;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import java.util.HashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+    @InjectMocks
+    private LoginService loginService;
+
+    @Mock
+    private JwtUtil jwtUtil;
+
+    @Mock
+    private KakaoService kakaoService;
+
+    @Mock
+    private RefreshTokenRedisService redisService;
+
+    @Test
+    @DisplayName("로그인 성공 테스트")
+    void loginSuccess() {
+        // given
+        Long authId = 1111L;
+        String accessToken = "testAccessToken";
+        String refreshToken = "testRefreshToken";
+        LoginRespDto loginResponse = LoginRespDto.builder()
+                .authId(authId)
+                .role(Role.USER)
+                .build();
+
+        when(kakaoService.getAccessToken(anyString())).thenReturn("mockKakaoAccessToken");
+        when(kakaoService.getUserInfo(anyString())).thenReturn(createMockKakaoUserInfoResponseDto());
+        when(kakaoService.join(any())).thenReturn(loginResponse);
+        when(jwtUtil.createAccessToken(anyLong(), any(Role.class))).thenReturn(accessToken);
+        when(jwtUtil.createRefreshToken(anyLong(), any(Role.class))).thenReturn(refreshToken);
+        doNothing().when(redisService).saveRefreshToken(anyLong(), anyString());
+
+        // when
+        TokenDto tokens = loginService.login("code");
+
+        // then
+        assertThat(tokens.getAccessToken()).isEqualTo(accessToken);
+        assertThat(tokens.getRefreshToken()).isEqualTo(refreshToken);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 재발급 성공")
+    void refreshSuccess() {
+        // given
+        LoginUser loginUser = new LoginUser(Member.builder().authId(1111L).role(Role.USER).build());
+        String savedRefreshToken = "testSavedRefreshToken";
+        String newAccessToken = "testNewAccessToken";
+        String newRefreshToken = "testNewRefreshToken";
+
+        when(jwtUtil.verify(anyString())).thenReturn(loginUser);
+        when(redisService.getRefreshToken(anyLong())).thenReturn(savedRefreshToken);
+        doNothing().when(redisService).deleteRefreshToken(anyLong());
+        when(jwtUtil.createAccessToken(anyLong(), any())).thenReturn(newAccessToken);
+        when(jwtUtil.createRefreshToken(anyLong(), any())).thenReturn(newRefreshToken);
+        doNothing().when(redisService).saveRefreshToken(anyLong(), anyString());
+
+        // when
+        TokenDto tokens = loginService.refresh(savedRefreshToken);
+
+        // then
+        assertThat(tokens.getAccessToken()).isEqualTo(newAccessToken);
+        assertThat(tokens.getRefreshToken()).isEqualTo(newRefreshToken);
+    }
+
+    @Test
+    @DisplayName("사용자 기존 리프레시 토큰과 요청한 리프레시 토큰이 일치하지 않을 경우 예외 발생")
+    void refreshFailRefreshTokenNotMatch() {
+        // given
+        LoginUser loginUser = new LoginUser(Member.builder().authId(1111L).role(Role.USER).build());
+
+        when(jwtUtil.verify(anyString())).thenReturn(loginUser);
+        when(redisService.getRefreshToken(anyLong())).thenReturn("testSavedRefreshToken");
+
+        // when
+        // then
+        assertThatThrownBy(() -> loginService.refresh("wrongRefreshToken"))
+                .isInstanceOf(RefreshTokenNotMatchException.class)
+                .hasMessage(FailedMessage.REFRESH_TOKEN_NOT_MATCH.getMessage());
+    }
+
+    private KakaoUserInfoResponseDto createMockKakaoUserInfoResponseDto() {
+        HashMap<String, String> properties = new HashMap<>();
+        properties.put("nickname", "testNickName");
+        properties.put("profile_image", "testProfileImage");
+
+        KakaoUserInfoResponseDto userInfo = new KakaoUserInfoResponseDto();
+        userInfo.setId(1111L);
+        userInfo.setProperties(properties);
+
+        return userInfo;
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/RefreshTokenRedisServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/RefreshTokenRedisServiceTest.java
@@ -1,0 +1,75 @@
+package com.carrot.carrotmarketclonecoding.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrot.carrotmarketclonecoding.RedisContainerConfig;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.redis.DataRedisTest;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DataRedisTest
+@ExtendWith(RedisContainerConfig.class)
+class RefreshTokenRedisServiceTest {
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    private static final String REFRESH_TOKEN_KEY_PREFIX = "refreshToken:";
+    private static final Long REFRESH_EXPIRATION_TIME = 1000L * 60 * 60L;
+
+    @AfterEach
+    void rollBack() {
+        Set<String> keys = redisTemplate.keys("*");
+        if (keys != null && !keys.isEmpty()) {
+            redisTemplate.delete(keys);
+        }
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 저장 및 조회")
+    void saveRefreshToken() {
+        // given
+        Long authId = 1111L;
+        String refreshToken = "refreshToken";
+
+        // when
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_KEY_PREFIX + authId,
+                refreshToken,
+                REFRESH_EXPIRATION_TIME,
+                TimeUnit.MILLISECONDS
+                );
+
+        // then
+        String savedRefreshToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_KEY_PREFIX + authId);
+        assertThat(savedRefreshToken).isEqualTo(refreshToken);
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 삭제")
+    void getRefreshToken() {
+        // given
+        Long authId = 1111L;
+        String refreshToken = "refreshToken";
+
+        // when
+        redisTemplate.opsForValue().set(REFRESH_TOKEN_KEY_PREFIX + authId,
+                refreshToken,
+                REFRESH_EXPIRATION_TIME,
+                TimeUnit.MILLISECONDS
+        );
+
+        redisTemplate.delete(REFRESH_TOKEN_KEY_PREFIX + authId);
+
+        // then
+        String savedRefreshToken = redisTemplate.opsForValue().get(REFRESH_TOKEN_KEY_PREFIX + authId);
+        assertThat(savedRefreshToken).isNull();
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/util/JwtUtilTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/util/JwtUtilTest.java
@@ -1,0 +1,104 @@
+package com.carrot.carrotmarketclonecoding.auth.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import java.util.Date;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class JwtUtilTest {
+
+    @InjectMocks
+    private JwtUtil jwtUtil;
+
+    private static final String SECRET = "testSecret";
+    private static final int EXPIRATION_TIME = 60000;
+    private static final long REFRESH_EXPIRATION_TIME = 1209600000L;
+
+    @BeforeEach
+    public void setUp() {
+        ReflectionTestUtils.setField(jwtUtil, "SECRET", SECRET);
+        ReflectionTestUtils.setField(jwtUtil, "EXPIRATION_TIME", EXPIRATION_TIME);
+        ReflectionTestUtils.setField(jwtUtil, "REFRESH_EXPIRATION_TIME", REFRESH_EXPIRATION_TIME);
+    }
+
+    @Test
+    @DisplayName("JWT 토큰 생성 테스트")
+    public void createAccessToken() {
+        // given
+        Long authId = 1L;
+        Role role = Role.USER;
+
+        // when
+        String token = jwtUtil.createAccessToken(authId, role);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token.startsWith(JwtVO.TOKEN_PREFIX)).isTrue();
+    }
+
+    @Test
+    @DisplayName("리프레시 토큰 생성 테스트")
+    public void testCreateRefreshToken() {
+        // given
+        Long authId = 1L;
+        Role role = Role.USER;
+
+        // when
+        String token = jwtUtil.createRefreshToken(authId, role);
+
+        // then
+        assertThat(token).isNotNull();
+        assertThat(token.startsWith(JwtVO.TOKEN_PREFIX)).isTrue();
+    }
+
+    @Test
+    @DisplayName("토큰 검증 테스트")
+    public void testVerify() {
+        // given
+        Long authId = 1L;
+        Role role = Role.USER;
+
+        String token = JWT.create()
+                .withSubject("token")
+                .withExpiresAt(new Date(System.currentTimeMillis() + EXPIRATION_TIME))
+                .withClaim("id", authId)
+                .withClaim("role", role.name())
+                .sign(Algorithm.HMAC512(SECRET));
+
+        token = JwtVO.TOKEN_PREFIX + token;
+
+        // when
+        LoginUser loginUser = jwtUtil.verify(token);
+
+        // then
+        assertThat(loginUser).isNotNull();
+        assertThat(authId).isEqualTo(loginUser.getMember().getAuthId());
+        assertThat(role).isEqualTo(loginUser.getMember().getRole());
+    }
+
+    @Test
+    @DisplayName("올바른 토큰이 아닐경우 예외 발생 테스트")
+    public void verifyFailTokenNotValid() {
+        // given
+        String invalidToken = JwtVO.TOKEN_PREFIX + "invalidToken";
+
+        // when
+        // then
+        assertThatThrownBy(() -> jwtUtil.verify(invalidToken))
+                .isInstanceOf(JWTVerificationException.class);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/util/LoginResponseUtilTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/util/LoginResponseUtilTest.java
@@ -1,0 +1,7 @@
+package com.carrot.carrotmarketclonecoding.auth.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class LoginResponseUtilTest {
+
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
@@ -50,7 +51,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(BoardController.class)
+@WebMvcTest(controllers = BoardController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class)
 class BoardControllerTest {
 
     @Autowired

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
@@ -25,13 +25,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(BoardLikeController.class)
+@WebMvcTest(controllers = BoardLikeController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class)
 class BoardLikeControllerTest {
 
     @Autowired

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
@@ -25,12 +25,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(SearchKeywordController.class)
+@WebMvcTest(controllers = SearchKeywordController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class)
 class SearchKeywordControllerTest {
 
     @Autowired

--- a/src/test/java/com/carrot/carrotmarketclonecoding/word/controller/WordControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/word/controller/WordControllerTest.java
@@ -16,6 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.carrot.carrotmarketclonecoding.board.controller.BoardController;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberWordLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.WordNotFoundException;
@@ -31,13 +32,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(WordController.class)
+@WebMvcTest(controllers = WordController.class,
+        excludeAutoConfiguration = SecurityAutoConfiguration.class)
 class WordControllerTest {
 
     @Autowired

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -25,3 +25,11 @@ s3:
     bucket: ENC(DYBumT/r/jJNVv0aIdXL0suri5bX5EeMZse+xuS5mfI=)
     accessKey: ENC(9I+FNe3mBV4sCcP+wF5Wo1E0tWxa5I6Qh2VpT0nHzuU=)
     secretKey: ENC(h6QDcliPmdblNeU+SluXUxywb09NhatUUjRI9RJoaUcFkCOSieRxNcp9SXjQ1gWjjFufORPP2BA=)
+
+kakao:
+  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+
+jwt:
+  secret: ENC(AZSMHtQVuCDzJNRt1ln9wKpeKm13cB6U9zIp23MOjjyBNIOqa+X7lMeAo8ki+bmW)
+  expiration_time: ENC(Lo7/s4mCESUiz0GI8/WYGA==)
+  refresh_expiration_time: ENC(k/35hOfhQC6TeZV6bs7KwhQo3I844ujZ)


### PR DESCRIPTION
## 구현 기능
- [x] 스프링 시큐리티 설정 클래스 추가
- [x] 클라이언트에서 카카오 서버로 로그인 시도후 설정된 redirect-uri로 전달받은 인가코드(code)를 서버로 전달
- [x] 서버에서 전달받은 인가코드(code)를 다시 카카오 서버로 전달해 액세스 토큰 요청
- [x] 응답받은 액세스 토큰을 통해 카카오로 사용자 정보를 요청
- [x] 응답받은 사용자 정보를 통해 JWT 액세스/리프레시 토큰 발급
- [x] 액세스/리프레시 토큰 발급 후 리프레시 토큰은 레디스에 사용자별로 저장
- [x] 매 요청마다 액세스 토큰 검사하는 JwtAuthorizationFilter 필터 구현
- [x] 액세스 토큰이 만료된경우 레디스에 저장된 사용자의 기존 리프레시 토큰과 비교 후 일치할경우 액세스/리프레시 토큰 재발급
- [x] 토큰 재발급 후 레디스의 사용자 리프레시 토큰 갱신

## 관련 이슈
resolved #71 