### PR TITLE
Feature#80

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -1,7 +1,14 @@
 package com.carrot.carrotmarketclonecoding.board.controller;
 
-import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_DELETE_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_GET_DETAIL_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_GET_TMP_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_REGISTER_TEMPORARY_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.BOARD_UPDATE_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.SEARCH_BOARDS_SUCCESS;
 
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
@@ -18,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -35,20 +43,18 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@ModelAttribute @Valid BoardRegisterRequestDto registerRequestDto) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        boardService.register(registerRequestDto, memberId, false);
+    public ResponseEntity<?> register(@AuthenticationPrincipal LoginUser loginUser, @ModelAttribute @Valid BoardRegisterRequestDto registerRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        boardService.register(registerRequestDto, authId, false);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ResponseResult.success(HttpStatus.CREATED, BOARD_REGISTER_SUCCESS.getMessage(), null));
     }
 
     @PostMapping("/register/tmp")
-    public ResponseEntity<?> registerTmp(@ModelAttribute BoardRegisterRequestDto registerRequestDto) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        boardService.register(registerRequestDto, memberId, true);
+    public ResponseEntity<?> registerTmp(@AuthenticationPrincipal LoginUser loginUser, @ModelAttribute BoardRegisterRequestDto registerRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        boardService.register(registerRequestDto, authId, true);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ResponseResult.success(HttpStatus.CREATED, BOARD_REGISTER_TEMPORARY_SUCCESS.getMessage(), null));
@@ -63,50 +69,45 @@ public class BoardController {
     }
 
     @GetMapping("/tmp")
-    public ResponseEntity<?> tmpDetail() {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        BoardDetailResponseDto boardDetail = boardService.tmpBoardDetail(memberId);
+    public ResponseEntity<?> tmpDetail(@AuthenticationPrincipal LoginUser loginUser) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        BoardDetailResponseDto boardDetail = boardService.tmpBoardDetail(authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_TMP_SUCCESS.getMessage(), boardDetail));
     }
 
     @GetMapping
-    public ResponseEntity<?> search(@RequestBody BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = null;
-        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(memberId, searchRequestDto, pageable);
+    public ResponseEntity<?> search(@AuthenticationPrincipal LoginUser loginUser, @RequestBody BoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        PageResponseDto<BoardSearchResponseDto> boards = boardService.search(authId, searchRequestDto, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
     }
 
     @GetMapping("/my")
-    public ResponseEntity<?> searchMyBoards(@RequestBody MyBoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        PageResponseDto<BoardSearchResponseDto> boards = boardService.searchMyBoards(memberId, searchRequestDto, pageable);
+    public ResponseEntity<?> searchMyBoards(@AuthenticationPrincipal LoginUser loginUser, @RequestBody MyBoardSearchRequestDto searchRequestDto, @PageableDefault(size = 10) Pageable pageable) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        PageResponseDto<BoardSearchResponseDto> boards = boardService.searchMyBoards(authId, searchRequestDto, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, SEARCH_BOARDS_SUCCESS.getMessage(), boards));
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable("id") Long boardId, @ModelAttribute @Valid BoardUpdateRequestDto updateRequestDto) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        boardService.update(updateRequestDto, boardId, memberId);
+    public ResponseEntity<?> update(@AuthenticationPrincipal LoginUser loginUser, @PathVariable("id") Long boardId, @ModelAttribute @Valid BoardUpdateRequestDto updateRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        boardService.update(updateRequestDto, boardId, authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_UPDATE_SUCCESS.getMessage(), null));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> delete(@PathVariable("id") Long boardId) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        boardService.delete(boardId, memberId);
+    public ResponseEntity<?> delete(@AuthenticationPrincipal LoginUser loginUser, @PathVariable("id") Long boardId) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        boardService.delete(boardId, authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_DELETE_SUCCESS.getMessage(), null));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeController.java
@@ -3,6 +3,7 @@ package com.carrot.carrotmarketclonecoding.board.controller;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.ADD_BOARD_LIKE_SUCCESS;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.GET_MEMBER_LIKED_BOARDS_SUCCESS;
 
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.service.BoardLikeService;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,21 +27,18 @@ public class BoardLikeController {
     private final BoardLikeService boardLikeService;
 
     @PostMapping("/{id}")
-    public ResponseEntity<?> addBoardLike(@PathVariable("id") Long boardId) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        boardLikeService.add(boardId, memberId);
+    public ResponseEntity<?> addBoardLike(@AuthenticationPrincipal LoginUser loginUser, @PathVariable("id") Long boardId) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        boardLikeService.add(boardId, authId);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ResponseResult.success(HttpStatus.CREATED, ADD_BOARD_LIKE_SUCCESS.getMessage(), null));
     }
 
     @GetMapping
-    public ResponseEntity<?> memberLikedBoards(@PageableDefault(size = 10) Pageable pageable) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        PageResponseDto<BoardSearchResponseDto> result = boardLikeService.getMemberLikedBoards(memberId,
-                pageable);
+    public ResponseEntity<?> memberLikedBoards(@AuthenticationPrincipal LoginUser loginUser, @PageableDefault(size = 10) Pageable pageable) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        PageResponseDto<BoardSearchResponseDto> result = boardLikeService.getMemberLikedBoards(authId, pageable);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, GET_MEMBER_LIKED_BOARDS_SUCCESS.getMessage(), result));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordController.java
@@ -2,26 +2,28 @@ package com.carrot.carrotmarketclonecoding.board.controller;
 
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
 
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordService;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @RestController
+@RequestMapping("/search")
 @RequiredArgsConstructor
 public class SearchKeywordController {
     private final SearchKeywordService searchKeywordService;
 
-    @GetMapping("/search/rank")
+    @GetMapping("/rank")
     public ResponseEntity<?> searchKeywordTopRank() {
         Set<String> keywords = searchKeywordService.getTopSearchKeywords();
         return ResponseEntity
@@ -29,31 +31,28 @@ public class SearchKeywordController {
                 .body(ResponseResult.success(HttpStatus.OK, GET_TOP_RANK_SEARCH_KEYWORDS_SUCCESS.getMessage(), keywords));
     }
 
-    @GetMapping("/search/recent")
-    public ResponseEntity<?> getRecentSearchKeywords() {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        List<String> keywords = searchKeywordService.getRecentSearchKeywords(memberId);
+    @GetMapping("/recent")
+    public ResponseEntity<?> getRecentSearchKeywords(@AuthenticationPrincipal LoginUser loginUser) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        List<String> keywords = searchKeywordService.getRecentSearchKeywords(authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, GET_RECENT_SEARCH_KEYWORDS_SUCCESS.getMessage(), keywords));
     }
 
-    @DeleteMapping("/search/recent")
-    public ResponseEntity<?> removeRecentKeyword(@RequestParam("keyword") String keyword) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        searchKeywordService.removeRecentSearchKeyword(memberId, keyword);
+    @DeleteMapping("/recent")
+    public ResponseEntity<?> removeRecentKeyword(@AuthenticationPrincipal LoginUser loginUser, @RequestParam("keyword") String keyword) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        searchKeywordService.removeRecentSearchKeyword(authId, keyword);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, REMOVE_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage(), null));
     }
 
-    @DeleteMapping("/search/recent/all")
-    public ResponseEntity<?> removeAllRecentKeywords() {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        searchKeywordService.removeAllRecentSearchKeywords(memberId);
+    @DeleteMapping("/recent/all")
+    public ResponseEntity<?> removeAllRecentKeywords(@AuthenticationPrincipal LoginUser loginUser) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        searchKeywordService.removeAllRecentSearchKeywords(authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, REMOVE_ALL_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage(), null));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepositoryCustom.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardRepositoryCustom {
-    Page<BoardSearchResponseDto> findAllByMemberAndSearchRequestDto(Member member, BoardSearchRequestDto searchRequestDto, Pageable pageable);
+    Page<BoardSearchResponseDto> findAllBySearchRequestDto(BoardSearchRequestDto searchRequestDto, Pageable pageable);
 
     Page<BoardSearchResponseDto> searchMemberLikedBoards(Member member, Pageable pageable);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/impl/BoardRepositoryCustomImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/impl/BoardRepositoryCustomImpl.java
@@ -35,11 +35,10 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
     }
 
     @Override
-    public Page<BoardSearchResponseDto> findAllByMemberAndSearchRequestDto(Member member, BoardSearchRequestDto searchRequestDto, Pageable pageable) {
+    public Page<BoardSearchResponseDto> findAllBySearchRequestDto(BoardSearchRequestDto searchRequestDto, Pageable pageable) {
         List<Board> boards = queryFactory
                 .selectFrom(board)
                 .where(
-                        memberEq(member),
                         titleContains(searchRequestDto.getKeyword()),
                         priceBetween(searchRequestDto.getMinPrice(), searchRequestDto.getMaxPrice()),
                         categoryEq(searchRequestDto.getCategoryId()),
@@ -55,7 +54,6 @@ public class BoardRepositoryCustomImpl implements BoardRepositoryCustom {
                 .select(board.count())
                 .from(board)
                 .where(
-                        memberEq(member),
                         titleContains(searchRequestDto.getKeyword()),
                         priceBetween(searchRequestDto.getMinPrice(), searchRequestDto.getMaxPrice()),
                         categoryEq(searchRequestDto.getCategoryId()),

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -10,17 +10,17 @@ import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardService {
-    Long register(BoardRegisterRequestDto registerRequestDto, Long memberId, boolean tmp);
+    Long register(BoardRegisterRequestDto registerRequestDto, Long authId, boolean tmp);
 
     BoardDetailResponseDto detail(Long boardId, String sessionId);
 
     BoardDetailResponseDto tmpBoardDetail(Long memberId);
 
-    PageResponseDto<BoardSearchResponseDto> search(Long memberId, BoardSearchRequestDto searchRequestDto, Pageable pageable);
+    PageResponseDto<BoardSearchResponseDto> search(Long authId, BoardSearchRequestDto searchRequestDto, Pageable pageable);
 
-    PageResponseDto<BoardSearchResponseDto> searchMyBoards(Long memberId, MyBoardSearchRequestDto searchRequestDto, Pageable pageable);
+    PageResponseDto<BoardSearchResponseDto> searchMyBoards(Long authId, MyBoardSearchRequestDto searchRequestDto, Pageable pageable);
 
-    void update(BoardUpdateRequestDto updateRequestDto, Long boardId, Long memberId);
+    void update(BoardUpdateRequestDto updateRequestDto, Long boardId, Long authId);
 
-    void delete(Long boardId, Long memberId);
+    void delete(Long boardId, Long authId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordRedisService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordRedisService.java
@@ -1,0 +1,13 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import java.util.List;
+import java.util.Set;
+
+public interface SearchKeywordRedisService {
+    void addSearchKeywordRank(String keyword);
+    Set<String> getTopSearchKeywords();
+    void addRecentSearchKeywords(Long memberId, String keyword);
+    List<String> getRecentSearchKeywords(Long memberId);
+    void removeRecentSearchKeyword(Long memberId, String keyword);
+    void removeAllRecentSearchKeywords(Long memberId);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordService.java
@@ -4,15 +4,8 @@ import java.util.List;
 import java.util.Set;
 
 public interface SearchKeywordService {
-    void addSearchKeywordRank(String keyword);
-
     Set<String> getTopSearchKeywords();
-
-    void addRecentSearchKeywords(Long memberId, String keyword);
-
-    List<String> getRecentSearchKeywords(Long memberId);
-
-    void removeRecentSearchKeyword(Long memberId, String keyword);
-
-    void removeAllRecentSearchKeywords(Long memberId);
+    List<String> getRecentSearchKeywords(Long authId);
+    void removeRecentSearchKeyword(Long authId, String keyword);
+    void removeAllRecentSearchKeywords(Long authId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
@@ -27,9 +27,9 @@ public class BoardLikeServiceImpl implements BoardLikeService {
     private final MemberRepository memberRepository;
 
     @Override
-    public void add(Long boardId, Long memberId) {
+    public void add(Long boardId, Long authId) {
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
 
         Optional<BoardLike> boardLike = boardLikeRepository.findByBoardAndMember(board, member);
         if (boardLike.isPresent()) {
@@ -44,8 +44,8 @@ public class BoardLikeServiceImpl implements BoardLikeService {
 
     @Override
     @Transactional(readOnly = true)
-    public PageResponseDto<BoardSearchResponseDto> getMemberLikedBoards(Long memberId, Pageable pageable) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public PageResponseDto<BoardSearchResponseDto> getMemberLikedBoards(Long authId, Pageable pageable) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         return new PageResponseDto<>(boardRepository.searchMemberLikedBoards(member, pageable));
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/SearchKeywordRedisServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/SearchKeywordRedisServiceImpl.java
@@ -1,0 +1,61 @@
+package com.carrot.carrotmarketclonecoding.board.service.impl;
+
+import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordRedisService;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class SearchKeywordRedisServiceImpl implements SearchKeywordRedisService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String SEARCH_RANK_KEY = "search:rank";
+    private static final String SEARCH_RECENT_KEY = "search:recent:";
+    private static final int MAX_RECENT_SEARCHES = 20;
+
+    @Override
+    public void addSearchKeywordRank(String keyword) {
+        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, keyword, 1);
+    }
+
+    @Override
+    public Set<String> getTopSearchKeywords() {
+        return redisTemplate.opsForZSet().reverseRange(SEARCH_RANK_KEY, 0, 9);
+    }
+
+    @Override
+    public void addRecentSearchKeywords(Long memberId, String keyword) {
+        String key = SEARCH_RECENT_KEY + memberId;
+
+        ListOperations<String, String> listOperations = redisTemplate.opsForList();
+        listOperations.remove(key, 1, keyword);
+        listOperations.rightPush(key, keyword);
+
+        if (listOperations.size(key) > MAX_RECENT_SEARCHES) {
+            listOperations.leftPop(key);
+        }
+    }
+
+    @Override
+    public List<String> getRecentSearchKeywords(Long memberId) {
+        String key = SEARCH_RECENT_KEY + memberId;
+        return redisTemplate.opsForList().range(key, 0, -1);
+    }
+
+    @Override
+    public void removeRecentSearchKeyword(Long memberId, String keyword) {
+        String key = SEARCH_RECENT_KEY + memberId;
+        redisTemplate.opsForList().remove(key, 0, keyword);
+    }
+
+    @Override
+    public void removeAllRecentSearchKeywords(Long memberId) {
+        redisTemplate.delete(SEARCH_RECENT_KEY + memberId);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/SearchKeywordServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/SearchKeywordServiceImpl.java
@@ -1,72 +1,41 @@
 package com.carrot.carrotmarketclonecoding.board.service.impl;
 
+import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordRedisService;
 import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordService;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import java.util.List;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.ListOperations;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class SearchKeywordServiceImpl implements SearchKeywordService {
-    private final RedisTemplate<String, String> redisTemplate;
     private final MemberRepository memberRepository;
-
-    private static final String SEARCH_RANK_KEY = "search:rank";
-    private static final String SEARCH_RECENT_KEY = "search:recent:";
-    private static final int MAX_RECENT_SEARCHES = 20;
-
-    @Override
-    public void addSearchKeywordRank(String keyword) {
-        redisTemplate.opsForZSet().incrementScore(SEARCH_RANK_KEY, keyword, 1);
-    }
+    private final SearchKeywordRedisService searchKeywordRedisService;
 
     @Override
     public Set<String> getTopSearchKeywords() {
-        return redisTemplate.opsForZSet().reverseRange(SEARCH_RANK_KEY, 0, 9);
+        return searchKeywordRedisService.getTopSearchKeywords();
     }
 
     @Override
-    public void addRecentSearchKeywords(Long memberId, String keyword) {
-        isMemberExist(memberId);
-        String key = SEARCH_RECENT_KEY + memberId;
-
-        ListOperations<String, String> listOperations = redisTemplate.opsForList();
-        listOperations.remove(key, 1, keyword);
-        listOperations.rightPush(key, keyword);
-
-        if (listOperations.size(key) > MAX_RECENT_SEARCHES) {
-            listOperations.leftPop(key);
-        }
+    public List<String> getRecentSearchKeywords(Long authId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        return searchKeywordRedisService.getRecentSearchKeywords(member.getId());
     }
 
     @Override
-    public List<String> getRecentSearchKeywords(Long memberId) {
-        isMemberExist(memberId);
-        String key = SEARCH_RECENT_KEY + memberId;
-        return redisTemplate.opsForList().range(key, 0, -1);
+    public void removeRecentSearchKeyword(Long authId, String keyword) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        searchKeywordRedisService.removeRecentSearchKeyword(member.getId(), keyword);
     }
 
     @Override
-    public void removeRecentSearchKeyword(Long memberId, String keyword) {
-        isMemberExist(memberId);
-        String key = SEARCH_RECENT_KEY + memberId;
-        redisTemplate.opsForList().remove(key, 0, keyword);
-    }
-
-    @Override
-    public void removeAllRecentSearchKeywords(Long memberId) {
-        isMemberExist(memberId);
-        redisTemplate.delete(SEARCH_RECENT_KEY + memberId);
-    }
-
-    private void isMemberExist(Long memberId) {
-        memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public void removeAllRecentSearchKeywords(Long authId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        searchKeywordRedisService.removeAllRecentSearchKeywords(member.getId());
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/word/controller/WordController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/word/controller/WordController.java
@@ -2,6 +2,7 @@ package com.carrot.carrotmarketclonecoding.word.controller;
 
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
 
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
 import com.carrot.carrotmarketclonecoding.word.dto.WordRequestDto;
 import com.carrot.carrotmarketclonecoding.word.dto.WordResponseDto.WordListResponseDto;
@@ -11,6 +12,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -27,40 +29,36 @@ public class WordController {
     private final WordService wordService;
 
     @PostMapping
-    public ResponseEntity<?> add(@RequestBody @Valid WordRequestDto wordRequestDto) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        wordService.add(memberId, wordRequestDto);
+    public ResponseEntity<?> add(@AuthenticationPrincipal LoginUser loginUser, @RequestBody @Valid WordRequestDto wordRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        wordService.add(authId, wordRequestDto);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ResponseResult.success(HttpStatus.CREATED, ADD_WORD_SUCCESS.getMessage(), null));
     }
 
     @GetMapping
-    public ResponseEntity<?> list() {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        List<WordListResponseDto> words = wordService.list(memberId);
+    public ResponseEntity<?> list(@AuthenticationPrincipal LoginUser loginUser) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        List<WordListResponseDto> words = wordService.list(authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, GET_MEMBER_WORDS.getMessage(), words));
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<?> update(@PathVariable("id") Long wordId, @RequestBody WordRequestDto wordRequestDto) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        wordService.update(memberId, wordId, wordRequestDto);
+    public ResponseEntity<?> update(@AuthenticationPrincipal LoginUser loginUser, @PathVariable("id") Long wordId, @RequestBody WordRequestDto wordRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        wordService.update(authId, wordId, wordRequestDto);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, UPDATE_WORD_SUCCESS.getMessage(), null));
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<?> remove(@PathVariable("id") Long wordId) {
-        // TODO memberId -> JWT.getMemberId()
-        Long memberId = 1L;
-        wordService.remove(memberId, wordId);
+    public ResponseEntity<?> remove(@AuthenticationPrincipal LoginUser loginUser, @PathVariable("id") Long wordId) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        wordService.remove(authId, wordId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, REMOVE_WORD_SUCCESS.getMessage(), null));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/word/service/WordService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/word/service/WordService.java
@@ -5,11 +5,11 @@ import com.carrot.carrotmarketclonecoding.word.dto.WordResponseDto.WordListRespo
 import java.util.List;
 
 public interface WordService {
-    void add(Long memberId, WordRequestDto wordRequestDto);
+    void add(Long authId, WordRequestDto wordRequestDto);
 
-    List<WordListResponseDto> list(Long memberId);
+    List<WordListResponseDto> list(Long authId);
 
-    void update(Long memberId, Long wordId, WordRequestDto wordRequestDto);
+    void update(Long authId, Long wordId, WordRequestDto wordRequestDto);
 
-    void remove(Long memberId, Long wordId);
+    void remove(Long authId, Long wordId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/word/service/impl/WordServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/word/service/impl/WordServiceImpl.java
@@ -25,8 +25,8 @@ public class WordServiceImpl implements WordService {
     private static final int WORD_LIMIT = 30;
 
     @Override
-    public void add(Long memberId, WordRequestDto wordRequestDto) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public void add(Long authId, WordRequestDto wordRequestDto) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         isWordTotalOverLimit(wordRepository.countByMember(member));
         Word word = Word.createWord(wordRequestDto, member);
         wordRepository.save(word);
@@ -34,22 +34,22 @@ public class WordServiceImpl implements WordService {
 
     @Override
     @Transactional(readOnly = true)
-    public List<WordListResponseDto> list(Long memberId) {
-        Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public List<WordListResponseDto> list(Long authId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         List<Word> words = wordRepository.findAllByMember(member);
         return words.stream().map(WordListResponseDto::createWordListResponseDto).toList();
     }
 
     @Override
-    public void update(Long memberId, Long wordId, WordRequestDto wordRequestDto) {
-        memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public void update(Long authId, Long wordId, WordRequestDto wordRequestDto) {
+        memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         Word word = wordRepository.findById(wordId).orElseThrow(WordNotFoundException::new);
         word.update(wordRequestDto);
     }
 
     @Override
-    public void remove(Long memberId, Long wordId) {
-        memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    public void remove(Long authId, Long wordId) {
+        memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         Word word = wordRepository.findById(wordId).orElseThrow(WordNotFoundException::new);
         wordRepository.delete(word);
     }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/config/WithCustomMockUser.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/config/WithCustomMockUser.java
@@ -1,0 +1,14 @@
+package com.carrot.carrotmarketclonecoding.auth.config;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithCustomMockUserSecurityContextFactory.class)
+public @interface WithCustomMockUser {
+
+    String username() default "1111";
+
+    String role() default "USER";
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/config/WithCustomMockUserSecurityContextFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/config/WithCustomMockUserSecurityContextFactory.java
@@ -1,0 +1,27 @@
+package com.carrot.carrotmarketclonecoding.auth.config;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+public class WithCustomMockUserSecurityContextFactory implements WithSecurityContextFactory<WithCustomMockUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithCustomMockUser annotation) {
+        String username = annotation.username();
+        String role = annotation.role();
+
+        LoginUser user = new LoginUser(Member.builder().authId(Long.parseLong(username)).build());
+
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(user, "password", List.of(new SimpleGrantedAuthority(role)));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -1,6 +1,6 @@
 package com.carrot.carrotmarketclonecoding.board.controller;
 
-import static com.carrot.carrotmarketclonecoding.board.BoardTestDisplayNames.MESSAGE.*;
+import static com.carrot.carrotmarketclonecoding.board.displayname.BoardTestDisplayNames.MESSAGE.*;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
 import static org.hamcrest.Matchers.equalTo;
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.SearchOrder;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
@@ -41,18 +42,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(controllers = BoardController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WithCustomMockUser
+@WebMvcTest(controllers = BoardController.class)
 class BoardControllerTest {
 
     @Autowired
@@ -69,12 +70,14 @@ class BoardControllerTest {
         @DisplayName(SUCCESS)
         void boardRegisterSuccess() throws Exception {
             // given
+
             // when
-            when(boardService.register(any(), anyLong(), anyBoolean())).thenReturn(1L);
+            when(boardService.register(any(), any(), anyBoolean())).thenReturn(1L);
 
             // then
             mvc.perform(post("/board/register")
-                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title")
                             .param("categoryId", "1")
                             .param("method", "SELL")
@@ -98,6 +101,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(post("/board/register/tmp")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title")
                             .param("categoryId", "1")
@@ -149,6 +153,7 @@ class BoardControllerTest {
                             .param("suggest", "true")
                             .param("description", "description")
                             .param("place", "place")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA))
                     .andExpect(status().isInternalServerError())
                     .andExpect(jsonPath("$.status", equalTo(500)))
@@ -167,6 +172,7 @@ class BoardControllerTest {
             // when
             // then
             mvc.perform(post("/board/register")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "")
                             .param("categoryId", "1")
@@ -191,6 +197,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(post("/board/register")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title")
                             .param("categoryId", "1")
@@ -215,6 +222,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(post("/board/register")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title")
                             .param("categoryId", "1")
@@ -260,13 +268,12 @@ class BoardControllerTest {
         @DisplayName(FAIL_BOARD_NOT_FOUND)
         void boardDetailBoardNotFound() throws Exception {
             // given
-            Long boardId = 1L;
 
             // when
             when(boardService.detail(anyLong(), anyString())).thenThrow(new BoardNotFoundException());
 
             // then
-            mvc.perform(get("/board/{id}", boardId))
+            mvc.perform(get("/board/{id}", 1L))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -294,7 +301,7 @@ class BoardControllerTest {
                     .build();
 
             // when
-            when(boardService.search(any(), any(), any())).thenReturn(response);
+            when(boardService.search(anyLong(), any(), any())).thenReturn(response);
 
             // then
             mvc.perform(get("/board")
@@ -397,6 +404,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(patch("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title2")
                             .param("categoryId", "2")
@@ -421,6 +429,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(patch("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title2")
                             .param("categoryId", "2")
@@ -445,6 +454,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(patch("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title2")
                             .param("categoryId", "2")
@@ -469,6 +479,7 @@ class BoardControllerTest {
 
             // then
             mvc.perform(patch("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.MULTIPART_FORM_DATA)
                             .param("title", "title2")
                             .param("categoryId", "2")
@@ -499,7 +510,8 @@ class BoardControllerTest {
             doNothing().when(boardService).delete(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/board/{id}", boardId))
+            mvc.perform(delete("/board/{id}", boardId)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.result", equalTo(true)))
@@ -517,7 +529,8 @@ class BoardControllerTest {
             doThrow(BoardNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/board/{id}", boardId))
+            mvc.perform(delete("/board/{id}", boardId)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -533,7 +546,8 @@ class BoardControllerTest {
             doThrow(MemberNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/board/{id}", 1L))
+            mvc.perform(delete("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -549,7 +563,8 @@ class BoardControllerTest {
             doThrow(UnauthorizedAccessException.class).when(boardService).delete(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/board/{id}", 1L))
+            mvc.perform(delete("/board/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isForbidden())
                     .andExpect(jsonPath("$.status", equalTo(403)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -607,7 +622,8 @@ class BoardControllerTest {
 
             // then
             mvc.perform(get("/board/tmp")
-                    .contentType(MediaType.APPLICATION_JSON))
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
@@ -1,6 +1,6 @@
 package com.carrot.carrotmarketclonecoding.board.controller;
 
-import static com.carrot.carrotmarketclonecoding.board.SearchKeywordTestDisplayNames.MESSAGE.*;
+import static com.carrot.carrotmarketclonecoding.board.displayname.SearchKeywordTestDisplayNames.MESSAGE.*;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
 import static org.hamcrest.Matchers.equalTo;
@@ -15,7 +15,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.carrot.carrotmarketclonecoding.board.service.impl.SearchKeywordServiceImpl;
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
+import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordService;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -25,21 +26,21 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = SearchKeywordController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WithCustomMockUser
+@WebMvcTest(controllers = SearchKeywordController.class)
 class SearchKeywordControllerTest {
 
     @Autowired
     private MockMvc mvc;
 
     @MockBean
-    private SearchKeywordServiceImpl searchKeywordService;
+    private SearchKeywordService searchKeywordService;
 
     @Nested
     @DisplayName(SEARCH_KEYWORD_TOP_RANK_CONTROLLER_TEST)
@@ -123,6 +124,7 @@ class SearchKeywordControllerTest {
 
             // then
             mvc.perform(delete("/search/recent")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .param("keyword", "keyword"))
                     .andExpect(status().isOk())
@@ -142,8 +144,9 @@ class SearchKeywordControllerTest {
 
             // then
             mvc.perform(delete("/search/recent")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .param("keyword", "keyword"))
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .param("keyword", "keyword"))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -164,7 +167,8 @@ class SearchKeywordControllerTest {
             doNothing().when(searchKeywordService).removeAllRecentSearchKeywords(anyLong());
 
             // then
-            mvc.perform(delete("/search/recent/all"))
+            mvc.perform(delete("/search/recent/all")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.result", equalTo(true)))
@@ -180,7 +184,8 @@ class SearchKeywordControllerTest {
             doThrow(MemberNotFoundException.class).when(searchKeywordService).removeAllRecentSearchKeywords(anyLong());
 
             // then
-            mvc.perform(delete("/search/recent/all"))
+            mvc.perform(delete("/search/recent/all")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardLikeTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardLikeTestDisplayNames.java
@@ -1,0 +1,27 @@
+package com.carrot.carrotmarketclonecoding.board.displayname;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum BoardLikeTestDisplayNames {
+    SUCCESS(MESSAGE.SUCCESS),
+    ADD_BOARD_LIKE_CONTROLLER_TEST(MESSAGE.ADD_BOARD_LIKE_CONTROLLER_TEST),
+    GET_BOARD_LIKE_LIST_CONTROLLER_TEST(MESSAGE.GET_BOARD_LIKE_LIST_CONTROLLER_TEST),
+    FAIL_BOARD_NOT_FOUND(MESSAGE.FAIL_BOARD_NOT_FOUND),
+    FAIL_MEMBER_NOT_FOUND(MESSAGE.FAIL_MEMBER_NOT_FOUND),
+    FAIL_BOARD_LIKE_ALREADY_ADDED(MESSAGE.FAIL_BOARD_LIKE_ALREADY_ADDED);
+
+    private final String message;
+
+    public static class MESSAGE {
+        public static final String ADD_BOARD_LIKE_CONTROLLER_TEST = "관심게시글 등록 컨트롤러 테스트";
+        public static final String GET_BOARD_LIKE_LIST_CONTROLLER_TEST = "관심게시글 목록 조회 컨트롤러 테스트";
+
+        public static final String FAIL_BOARD_NOT_FOUND = "실패 - 게시글이 존재하지 않음";
+        public static final String FAIL_MEMBER_NOT_FOUND = "실패 - 사용자가 존재하지 않음";
+        public static final String FAIL_BOARD_LIKE_ALREADY_ADDED = "실패 - 사용자가 이미 관심게시글로 등록한 게시글임";
+        public static final String SUCCESS = "성공";
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardTestDisplayNames.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.board;
+package com.carrot.carrotmarketclonecoding.board.displayname;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/SearchKeywordTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/SearchKeywordTestDisplayNames.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.board;
+package com.carrot.carrotmarketclonecoding.board.displayname;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
@@ -64,7 +64,7 @@ class BoardLikeServiceTest {
             Member mockMember = mock(Member.class);
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
             // when
             boardLikeService.add(boardId, memberId);
@@ -81,13 +81,11 @@ class BoardLikeServiceTest {
         @DisplayName("실패 - 게시글 존재하지 않음")
         void addBoardLikeFailBoardNotFound() {
             // given
-            Long boardId = 1L;
-            Long memberId = 1L;
             when(boardRepository.findById(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
-            assertThatThrownBy(() -> boardLikeService.add(boardId, memberId))
+            assertThatThrownBy(() -> boardLikeService.add(1L, 1L))
                     .isInstanceOf(BoardNotFoundException.class)
                     .hasMessage(BOARD_NOT_FOUND.getMessage());
         }
@@ -96,16 +94,12 @@ class BoardLikeServiceTest {
         @DisplayName("실패 - 사용자 존재하지 않음")
         void addBoardLikeFailMemberNotFound() {
             // given
-            Long boardId = 1L;
-            Long memberId = 1L;
-            Board mockBoard = mock(Board.class);
-
-            when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mock(Board.class)));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
-            assertThatThrownBy(() -> boardLikeService.add(boardId, memberId))
+            assertThatThrownBy(() -> boardLikeService.add(1L, 1L))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
@@ -114,19 +108,13 @@ class BoardLikeServiceTest {
         @DisplayName("실패 - 사용자가 이미 관심게시글로 등록한 게시글임")
         void addBoardLikeFailMemberAlreadyLikedBoard() {
             // given
-            Long boardId = 1L;
-            Long memberId = 1L;
-            Board mockBoard = mock(Board.class);
-            Member mockMember = mock(Member.class);
-            BoardLike mockBoardLike = mock(BoardLike.class);
-
-            when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
-            when(boardLikeRepository.findByBoardAndMember(any(), any())).thenReturn(Optional.of(mockBoardLike));
+            when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mock(Board.class)));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
+            when(boardLikeRepository.findByBoardAndMember(any(), any())).thenReturn(Optional.of(mock(BoardLike.class)));
 
             // when
             // then
-            assertThatThrownBy(() -> boardLikeService.add(boardId, memberId))
+            assertThatThrownBy(() -> boardLikeService.add(1L, 1L))
                     .isInstanceOf(MemberAlreadyLikedBoardException.class)
                     .hasMessage(MEMBER_ALREADY_LIKED_BOARD.getMessage());
         }
@@ -140,19 +128,17 @@ class BoardLikeServiceTest {
         @DisplayName("성공")
         void memberLikedBoardsSuccess() {
             // given
-            Long memberId = 1L;
-            Member mockMember = mock(Member.class);
             Pageable pageable = PageRequest.of(0, 10);
             List<BoardSearchResponseDto> boardSearchResponse = Arrays.asList(
                     new BoardSearchResponseDto(),
                     new BoardSearchResponseDto()
             );
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
             when(boardRepository.searchMemberLikedBoards(any(), any())).thenReturn(new PageImpl<>(boardSearchResponse, pageable, boardSearchResponse.size()));
 
             // when
-            PageResponseDto<BoardSearchResponseDto> result = boardLikeService.getMemberLikedBoards(memberId, pageable);
+            PageResponseDto<BoardSearchResponseDto> result = boardLikeService.getMemberLikedBoards(1L, pageable);
 
             // then
             assertThat(result.getContents().size()).isEqualTo(2);
@@ -162,7 +148,7 @@ class BoardLikeServiceTest {
         @DisplayName("실패 - 사용자가 존재하지 않음")
         void memberLikedBoardsFailMemberNotFound() {
             // given
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardPictureServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardPictureServiceTest.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.board.service.impl;
+package com.carrot.carrotmarketclonecoding.board.service;
 
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
 import static org.assertj.core.api.Assertions.*;
@@ -9,6 +9,7 @@ import static org.mockito.internal.verification.VerificationModeFactory.times;
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepository;
+import com.carrot.carrotmarketclonecoding.board.service.impl.BoardPictureService;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.file.service.impl.FileServiceImpl;
 import java.util.stream.IntStream;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordRedisServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/SearchKeywordRedisServiceTest.java
@@ -19,7 +19,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DataRedisTest
 @ExtendWith(RedisContainerConfig.class)
-class SearchKeywordServiceTest {
+class SearchKeywordRedisServiceTest {
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/word/controller/WordControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/word/controller/WordControllerTest.java
@@ -2,7 +2,7 @@ package com.carrot.carrotmarketclonecoding.word.controller;
 
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
-import static com.carrot.carrotmarketclonecoding.word.WordTestDisplayNames.MESSAGE.*;
+import static com.carrot.carrotmarketclonecoding.word.displayname.WordTestDisplayNames.MESSAGE.*;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.carrot.carrotmarketclonecoding.board.controller.BoardController;
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberWordLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.WordNotFoundException;
@@ -32,15 +32,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(controllers = WordController.class,
-        excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WithCustomMockUser
+@WebMvcTest(controllers = WordController.class)
 class WordControllerTest {
 
     @Autowired
@@ -62,6 +62,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(post("/word")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isCreated())
@@ -81,6 +82,7 @@ class WordControllerTest {
             // when
             // then
             mvc.perform(post("/word")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto())))
                     .andExpect(status().isBadRequest())
@@ -100,6 +102,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(post("/word")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isUnauthorized())
@@ -118,6 +121,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(post("/word")
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isBadRequest())
@@ -183,6 +187,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(put("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isOk())
@@ -201,6 +206,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(put("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isUnauthorized())
@@ -219,6 +225,7 @@ class WordControllerTest {
 
             // then
             mvc.perform(put("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(new ObjectMapper().writeValueAsString(new WordRequestDto("word"))))
                     .andExpect(status().isBadRequest())
@@ -242,7 +249,8 @@ class WordControllerTest {
             doNothing().when(wordService).remove(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/word/{id}", 1L))
+            mvc.perform(delete("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.status", equalTo(200)))
                     .andExpect(jsonPath("$.result", equalTo(true)))
@@ -258,7 +266,8 @@ class WordControllerTest {
             doThrow(MemberNotFoundException.class).when(wordService).remove(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/word/{id}", 1L))
+            mvc.perform(delete("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.status", equalTo(401)))
                     .andExpect(jsonPath("$.result", equalTo(false)))
@@ -274,7 +283,8 @@ class WordControllerTest {
             doThrow(WordNotFoundException.class).when(wordService).remove(anyLong(), anyLong());
 
             // then
-            mvc.perform(delete("/word/{id}", 1L))
+            mvc.perform(delete("/word/{id}", 1L)
+                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.status", equalTo(400)))
                     .andExpect(jsonPath("$.result", equalTo(false)))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/word/displayname/WordTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/word/displayname/WordTestDisplayNames.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.word;
+package com.carrot.carrotmarketclonecoding.word.displayname;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/word/service/WordServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/word/service/WordServiceTest.java
@@ -1,7 +1,7 @@
 package com.carrot.carrotmarketclonecoding.word.service;
 
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
-import static com.carrot.carrotmarketclonecoding.word.WordTestDisplayNames.MESSAGE.*;
+import static com.carrot.carrotmarketclonecoding.word.displayname.WordTestDisplayNames.MESSAGE.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -55,7 +55,7 @@ class WordServiceTest {
             Member mockMember = mock(Member.class);
             WordRequestDto wordRequestDto = new WordRequestDto("word");
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
             when(wordRepository.countByMember(any())).thenReturn(10);
 
             // when
@@ -75,7 +75,7 @@ class WordServiceTest {
             Long memberId = 1L;
             WordRequestDto wordRequestDto = new WordRequestDto("word");
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
@@ -92,7 +92,7 @@ class WordServiceTest {
             Member mockMember = mock(Member.class);
             WordRequestDto wordRequestDto = new WordRequestDto("word");
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
             when(wordRepository.countByMember(any())).thenReturn(30);
 
             // when
@@ -117,7 +117,7 @@ class WordServiceTest {
                     Word.builder().id(2L).word("word2").build()
             );
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mock(Member.class)));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
             when(wordRepository.findAllByMember(any())).thenReturn(words);
 
             // when
@@ -135,13 +135,11 @@ class WordServiceTest {
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void getWordsFailMemberNotFound() {
             // given
-            Long memberId = 1L;
-
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
-            assertThatThrownBy(() -> wordService.list(memberId))
+            assertThatThrownBy(() -> wordService.list(1L))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
@@ -160,7 +158,7 @@ class WordServiceTest {
             Member mockMember = mock(Member.class);
             Word mockWord = Word.builder().word("word1").build();
 
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
             when(wordRepository.findById(anyLong())).thenReturn(Optional.of(mockWord));
 
             // when
@@ -174,7 +172,7 @@ class WordServiceTest {
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void updateWordFailMemberNotFound() {
             // given
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
@@ -187,7 +185,7 @@ class WordServiceTest {
         @DisplayName(FAIL_WORD_NOT_FOUND)
         void updateWordFailWordNotFound() {
             // given
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mock(Member.class)));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
             when(wordRepository.findById(anyLong())).thenReturn(Optional.empty());
 
             // when
@@ -210,7 +208,7 @@ class WordServiceTest {
             Long wordId = 1L;
             Member mockMember = mock(Member.class);
             Word mockWord = mock(Word.class);
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mockMember));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
             when(wordRepository.findById(anyLong())).thenReturn(Optional.of(mockWord));
 
             // when
@@ -224,7 +222,7 @@ class WordServiceTest {
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void removeWordFailMemberNotFound() {
             // given
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.empty());
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
 
             // when
             // then
@@ -237,7 +235,7 @@ class WordServiceTest {
         @DisplayName(FAIL_WORD_NOT_FOUND)
         void removeWordFailWordNotFound() {
             // given
-            when(memberRepository.findById(anyLong())).thenReturn(Optional.of(mock(Member.class)));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
             when(wordRepository.findById(anyLong())).thenReturn(Optional.empty());
 
             // when


### PR DESCRIPTION
## 구현 기능
- [x] 기존 컨트롤러 로직에서 고정된 사용자 아이디를 사용하는 부분을 현재 로그인한 사용자의 카카오 아이디를 가져오는 것으로 변경
- [x] 변경된 내용에 따라 테스트 케이스 수정
- [x] 테스트 케이스에서 정의한 인증된 사용자를 불러올 수 있도록 커스텀 어노테이션 @CustomWithMockUser 생성
- [x] QueryDsl에서 현재 로그인한 사용자의 게시글 내에서 검색되지는 문제 수정 (전체 게시글에서 검색을 수행하게끔 변경)

## 관련 이슈
resolved #80