### PR TITLE
회원탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
@@ -2,6 +2,7 @@ package com.carrot.carrotmarketclonecoding.auth.controller;
 
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.RECREATE_TOKENS_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.WITHDRAW_SUCCESS;
 
 import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
@@ -43,6 +44,6 @@ public class KakaoLoginController {
         loginService.withdraw(Long.parseLong(loginUser.getUsername()));
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(ResponseResult.success(HttpStatus.OK, "회원탈퇴에 성공하였습니다!", null));
+                .body(ResponseResult.success(HttpStatus.OK, WITHDRAW_SUCCESS.getMessage(), null));
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
@@ -3,13 +3,16 @@ package com.carrot.carrotmarketclonecoding.auth.controller;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.RECREATE_TOKENS_SUCCESS;
 
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
 import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -17,7 +20,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 public class KakaoLoginController {
-
     private final LoginService loginService;
 
     @GetMapping("/callback")
@@ -34,5 +36,13 @@ public class KakaoLoginController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, RECREATE_TOKENS_SUCCESS.getMessage(), tokens));
+    }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<?> withdraw(@AuthenticationPrincipal LoginUser loginUser) {
+        loginService.withdraw(Long.parseLong(loginUser.getUsername()));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, "회원탈퇴에 성공하였습니다!", null));
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/handler/LogoutHandlerImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/handler/LogoutHandlerImpl.java
@@ -1,7 +1,8 @@
-package com.carrot.carrotmarketclonecoding.auth.service;
+package com.carrot.carrotmarketclonecoding.auth.handler;
 
 import com.carrot.carrotmarketclonecoding.auth.dto.JwtVO;
 import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
 import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,13 +15,13 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 @RequiredArgsConstructor
 public class LogoutHandlerImpl implements LogoutHandler {
     private final JwtUtil jwtUtil;
-    private final RefreshTokenRedisService redisService;
+    private final LoginService loginService;
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
         log.debug("LogoutHandler 동작중...");
 
         LoginUser loginUser = jwtUtil.verify(request.getHeader(JwtVO.HEADER));
-        redisService.deleteRefreshToken(Long.parseLong(loginUser.getUsername()));
+        loginService.logout(Long.parseLong(loginUser.getUsername()));
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/handler/LogoutSuccessHandlerImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/handler/LogoutSuccessHandlerImpl.java
@@ -1,4 +1,4 @@
-package com.carrot.carrotmarketclonecoding.auth.service;
+package com.carrot.carrotmarketclonecoding.auth.handler;
 
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGOUT_SUCCESS;
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoService.java
@@ -1,22 +1,20 @@
 package com.carrot.carrotmarketclonecoding.auth.service;
 
-import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
-import com.carrot.carrotmarketclonecoding.common.exception.KakaoTokenNotExistsException;
-import com.carrot.carrotmarketclonecoding.common.exception.KakaoUserInfoNotExistsException;
 import com.carrot.carrotmarketclonecoding.auth.dto.KakaoTokenResponseDto;
 import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
-import com.carrot.carrotmarketclonecoding.member.domain.Member;
-import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
-import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
-import java.util.Optional;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoTokenNotExistsException;
+import com.carrot.carrotmarketclonecoding.common.exception.KakaoUserInfoNotExistsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -28,18 +26,24 @@ public class KakaoService {
     @Value("${kakao.client_id}")
     private String clientId;
 
+    @Value("${kakao.admin-key}")
+    private String adminKey;
+
     private static final String KAUTH_TOKEN_URL_HOST = "https://kauth.kakao.com/oauth/token";
     private static final String KAUTH_USER_URL_HOST = "https://kapi.kakao.com/v2/user/me";
-    private static final String KAKAO_REQUEST_HEADER = "Bearer ";
-    private static final String CONTENT_TYPE = "application/x-www-form-urlencoded";
-    private static final String PROPERTY_NICKNAME = "nickname";
-    private static final String PROPERTY_PROFILE_IMAGE = "profile_image";
+    private static final String KAUTH_UNLINK_URL_HOST = "https://kapi.kakao.com/v1/user/unlink";
+    private static final String KAUTH_LOGOUT_URL_HOST = "https://kapi.kakao.com/v1/user/logout";
+
     private static final String PARAM_GRANT_TYPE = "grant_type";
     private static final String PARAM_CLIENT_ID = "client_id";
     private static final String PARAM_CODE = "code";
     private static final String GRANT_TYPE_VALUE = "authorization_code";
+    private static final String PARAM_TARGET_ID_TYPE = "target_id_type";
+    private static final String PARAM_TARGET_ID = "target_id";
+    private static final String VALUE_USER_ID = "user_id";
 
-    private final MemberRepository memberRepository;
+    private static final String UNLINK_AND_LOGOUT_HEADER_PREFIX = "KakaoAK ";
+
     private final RestTemplate restTemplate;
 
     public String getAccessToken(String code) {
@@ -50,7 +54,7 @@ public class KakaoService {
                 .toUriString();
 
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<KakaoTokenResponseDto> responseEntity = restTemplate.exchange(
@@ -65,18 +69,13 @@ public class KakaoService {
             throw new KakaoTokenNotExistsException();
         }
 
-        log.debug(" [Kakao Service] Access Token ------> {}", kakaoTokenResponseDto.getAccessToken());
-        log.debug(" [Kakao Service] Refresh Token ------> {}", kakaoTokenResponseDto.getRefreshToken());
-        log.debug(" [Kakao Service] Id Token ------> {}", kakaoTokenResponseDto.getIdToken());
-        log.debug(" [Kakao Service] Scope ------> {}", kakaoTokenResponseDto.getScope());
-
         return kakaoTokenResponseDto.getAccessToken();
     }
 
     public KakaoUserInfoResponseDto getUserInfo(String accessToken) {
         HttpHeaders headers = new HttpHeaders();
-        headers.set(HttpHeaders.AUTHORIZATION, KAKAO_REQUEST_HEADER + accessToken);
-        headers.set(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE);
+        headers.setBearerAuth(accessToken);
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
         HttpEntity<String> entity = new HttpEntity<>(headers);
         ResponseEntity<KakaoUserInfoResponseDto> responseEntity = restTemplate.exchange(
@@ -92,33 +91,34 @@ public class KakaoService {
         }
 
         log.debug("[ Kakao Service ] Auth ID ---> {} ", userInfo.getId());
-        log.debug("[ Kakao Service ] NickName ---> {} ", userInfo.getProperties().get(PROPERTY_NICKNAME));
-        log.debug("[ Kakao Service ] ProfileImageUrl ---> {} ", userInfo.getProperties().get(PROPERTY_PROFILE_IMAGE));
 
         return userInfo;
     }
 
-    public LoginRespDto join(KakaoUserInfoResponseDto userInfo) {
-        Optional<Member> optionalMember = memberRepository.findByAuthId(userInfo.getId());
-        Member member = null;
+    public void logout(Long authId) {
+        kakaoRequest(authId, KAUTH_LOGOUT_URL_HOST);
+    }
 
-        if (optionalMember.isPresent()) {
-            member = optionalMember.get();
-        } else {
-            member = memberRepository.save(Member.builder()
-                    .authId(userInfo.getId())
-                    .nickname(userInfo.getProperties().get(PROPERTY_NICKNAME))
-                    .profileUrl(userInfo.getProperties().get(PROPERTY_PROFILE_IMAGE))
-                    .town(null)
-                    .withdraw(false)
-                    .isTownAuthenticated(false)
-                    .role(Role.USER)
-                    .build());
-        }
+    public void unlink(Long authId) {
+        kakaoRequest(authId, KAUTH_UNLINK_URL_HOST);
+    }
 
-        return LoginRespDto.builder()
-                .authId(member.getAuthId())
-                .role(member.getRole())
-                .build();
+    private void kakaoRequest(Long authId, String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set(HttpHeaders.AUTHORIZATION, UNLINK_AND_LOGOUT_HEADER_PREFIX + adminKey);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(PARAM_TARGET_ID_TYPE, VALUE_USER_ID);
+        params.add(PARAM_TARGET_ID, String.valueOf(authId));
+
+        HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+        ResponseEntity<String> result = restTemplate.exchange(
+                url,
+                HttpMethod.POST,
+                entity,
+                String.class);
+
+        log.debug("[ Kakao Service ] unlink, logout result ---> {} ", result.getBody());
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/LoginService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/service/LoginService.java
@@ -5,55 +5,107 @@ import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
 import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
 import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.RefreshTokenNotMatchException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class LoginService {
 
+    private static final String PROPERTY_NICKNAME = "nickname";
+    private static final String PROPERTY_PROFILE_IMAGE = "profile_image";
+
     private final JwtUtil jwtUtil;
     private final KakaoService kakaoService;
-    private final RefreshTokenRedisService redisService;
+    private final RefreshTokenRedisService refreshTokenRedisService;
+    private final MemberRepository memberRepository;
+    private final BoardLikeRepository boardLikeRepository;
+    private final BoardRepository boardRepository;
 
     public TokenDto login(String code) {
-        String kakaoAccessToken = kakaoService.getAccessToken(code);
-        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(kakaoAccessToken);
-        LoginRespDto loginResponse = kakaoService.join(userInfo);
-
+        LoginRespDto loginResponse = kakaoLogin(code);
         Long authId = loginResponse.getAuthId();
-        Role role = loginResponse.getRole();
-        String accessToken = jwtUtil.createAccessToken(authId, role);
-        String refreshToken = jwtUtil.createRefreshToken(authId, role);
-        redisService.saveRefreshToken(authId, refreshToken);
-
-        return TokenDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .build();
+        TokenDto tokens = createTokenDto(authId, loginResponse.getRole());
+        refreshTokenRedisService.saveRefreshToken(authId, tokens.getRefreshToken());
+        return tokens;
     }
 
     public TokenDto refresh(String refreshToken) {
         LoginUser user = jwtUtil.verify(refreshToken);
-        Long authId = user.getMember().getAuthId();
-        Role role = user.getMember().getRole();
-
-        String savedRefreshToken = redisService.getRefreshToken(authId);
+        Long authId = Long.parseLong(user.getUsername());
+        String savedRefreshToken = refreshTokenRedisService.getRefreshToken(authId);
         if (!savedRefreshToken.equals(refreshToken)) {
             throw new RefreshTokenNotMatchException();
         }
 
-        redisService.deleteRefreshToken(authId);
+        TokenDto tokens = createTokenDto(authId, user.getMember().getRole());
+        refreshTokenRedisService.deleteRefreshToken(authId);
+        refreshTokenRedisService.saveRefreshToken(authId, tokens.getRefreshToken());
+        return tokens;
+    }
 
-        String accessToken = jwtUtil.createAccessToken(authId, role);
-        String newRefreshToken = jwtUtil.createRefreshToken(authId, role);
-        redisService.saveRefreshToken(authId, newRefreshToken);
+    public void logout(Long authId) {
+        kakaoService.logout(authId);
+        refreshTokenRedisService.deleteRefreshToken(authId);
+    }
 
-        return TokenDto.builder()
-                .accessToken(accessToken)
-                .refreshToken(newRefreshToken)
+    @Transactional
+    public void withdraw(Long authId) {
+        kakaoService.unlink(authId);
+        refreshTokenRedisService.deleteRefreshToken(authId);
+        deleteAllMemberData(authId);
+    }
+
+    private LoginRespDto kakaoLogin(String code) {
+        String kakaoAccessToken = kakaoService.getAccessToken(code);
+        KakaoUserInfoResponseDto userInfo = kakaoService.getUserInfo(kakaoAccessToken);
+        return joinIfMemberNotExits(userInfo);
+    }
+
+    private LoginRespDto joinIfMemberNotExits(KakaoUserInfoResponseDto userInfo) {
+        Optional<Member> optionalMember = memberRepository.findByAuthId(userInfo.getId());
+        Member member = null;
+
+        if (optionalMember.isPresent()) {
+            member = optionalMember.get();
+        } else {
+            member = saveMemberWithKakaoUserInfo(userInfo);
+        }
+
+        return LoginRespDto.builder()
+                .authId(member.getAuthId())
+                .role(member.getRole())
                 .build();
+    }
+
+    private Member saveMemberWithKakaoUserInfo(KakaoUserInfoResponseDto userInfo) {
+        return memberRepository.save(Member.builder()
+                .authId(userInfo.getId())
+                .nickname(userInfo.getProperties().get(PROPERTY_NICKNAME))
+                .profileUrl(userInfo.getProperties().get(PROPERTY_PROFILE_IMAGE))
+                .town(null)
+                .isTownAuthenticated(false)
+                .role(Role.USER)
+                .build());
+    }
+
+    private TokenDto createTokenDto(Long authId, Role role) {
+        return new TokenDto(jwtUtil.createAccessToken(authId, role), jwtUtil.createRefreshToken(authId, role));
+    }
+
+    private void deleteAllMemberData(Long authId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        boardLikeRepository.deleteAllByMemberId(member.getId());
+        boardRepository.deleteAllByMemberId(member.getId());
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardLikeRepository.java
@@ -15,4 +15,8 @@ public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
     @Modifying
     @Query("DELETE FROM BoardLike b WHERE b.board.id = :boardId")
     void deleteAllByBoardId(Long boardId);
+
+    @Modifying
+    @Query("DELETE FROM BoardLike b WHERE b.member.id = :memberId")
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/repository/BoardRepository.java
@@ -4,8 +4,14 @@ import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BoardRepository extends JpaRepository<Board, Long>, BoardRepositoryCustom {
     void deleteAllByMemberAndTmpIsTrueAndIdIsNot(Member member, Long id);
     Optional<Board> findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(Member member);
+
+    @Modifying
+    @Query("DELETE FROM Board b WHERE b.member.id = :memberId")
+    void deleteAllByMemberId(Long memberId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -28,7 +28,8 @@ public enum SuccessMessage {
 
     LOGIN_SUCCESS("로그인에 성공하였습니다!"),
     RECREATE_TOKENS_SUCCESS("토큰 재발급에 성공하였습니다!"),
-    LOGOUT_SUCCESS("로그아웃에 성공하였습니다!");
+    LOGOUT_SUCCESS("로그아웃에 성공하였습니다!"),
+    WITHDRAW_SUCCESS("회원탈퇴에 성공하였습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
@@ -4,9 +4,9 @@ import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.F
 
 import com.carrot.carrotmarketclonecoding.auth.exception.CustomAuthenticationEntryPoint;
 import com.carrot.carrotmarketclonecoding.auth.filter.JwtAuthorizationFilter;
-import com.carrot.carrotmarketclonecoding.auth.service.LogoutHandlerImpl;
-import com.carrot.carrotmarketclonecoding.auth.service.LogoutSuccessHandlerImpl;
-import com.carrot.carrotmarketclonecoding.auth.service.RefreshTokenRedisService;
+import com.carrot.carrotmarketclonecoding.auth.handler.LogoutHandlerImpl;
+import com.carrot.carrotmarketclonecoding.auth.handler.LogoutSuccessHandlerImpl;
+import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
 import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
 import com.carrot.carrotmarketclonecoding.auth.util.ResponseUtil;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtUtil jwtUtil;
-    private final RefreshTokenRedisService redisService;
+    private final LoginService loginService;
 
     @Bean
     public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
@@ -45,7 +45,7 @@ public class SecurityConfig {
 
     @Bean
     public LogoutHandlerImpl logoutHandlerService() {
-        return new LogoutHandlerImpl(jwtUtil, redisService);
+        return new LogoutHandlerImpl(jwtUtil, loginService);
     }
 
     @Bean

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
@@ -25,7 +25,6 @@ public class Member extends BaseEntity {
     private String nickname;
     private String profileUrl;
     private String town;
-    private Boolean withdraw;
     private Boolean isTownAuthenticated;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -23,7 +23,3 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: blue_server
-
-kakao:
-  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
-  redirect_uri: ENC(4+7kO9DaQ/b2Z2ebMbE7FQeoB2zHMoTIl2zwwtAqhRChhm5FOJtD7H9VYJYpEkrb)

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -23,7 +23,3 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: green_server
-
-kakao:
-  client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
-  redirect_uri: ENC(WvpjgCPvXXjgl/3C5daeUdnQ3rupSqr+l7JbiJTNgSortNlpDAo5e8Lu7e468DQM)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,6 +25,7 @@ s3:
 
 kakao:
   client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+  admin-key: ENC(XX6kopdlBAf5/uJgp2P8qWu1nDjxQ3wL+UWnWFA8zm5BDas5s1PI7lPYO7wnJZf1)
 
 jwt:
   secret: ENC(AZSMHtQVuCDzJNRt1ln9wKpeKm13cB6U9zIp23MOjjyBNIOqa+X7lMeAo8ki+bmW)

--- a/src/main/resources/db/migration/V4__alter_table_members.sql
+++ b/src/main/resources/db/migration/V4__alter_table_members.sql
@@ -1,0 +1,1 @@
+ALTER TABLE members DROP COLUMN withdraw;

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginControllerTest.java
@@ -1,28 +1,36 @@
 package com.carrot.carrotmarketclonecoding.auth.controller;
 
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.REFRESH_TOKEN_NOT_MATCH;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.LOGIN_SUCCESS;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.RECREATE_TOKENS_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.WITHDRAW_SUCCESS;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
 import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
 import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.RefreshTokenNotMatchException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(controllers = KakaoLoginController.class, excludeAutoConfiguration = SecurityAutoConfiguration.class)
+@WithCustomMockUser
+@WebMvcTest(controllers = KakaoLoginController.class)
 class KakaoLoginControllerTest {
 
     @Autowired
@@ -32,7 +40,7 @@ class KakaoLoginControllerTest {
     private LoginService loginService;
 
     @Test
-    @DisplayName("카카오 redirect-uri 테스트")
+    @DisplayName("카카오 로그인 테스트")
     void callback() throws Exception {
         // given
         TokenDto tokens = TokenDto.builder()
@@ -45,7 +53,7 @@ class KakaoLoginControllerTest {
 
         // then
         mvc.perform(get("/callback")
-                .param("code", "code"))
+                        .param("code", "code"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.result", equalTo(true)))
@@ -55,7 +63,7 @@ class KakaoLoginControllerTest {
     }
 
     @Test
-    @DisplayName("리프레시 토큰 갱신 테스트")
+    @DisplayName("JWT 토큰 갱신 테스트")
     void refresh() throws Exception {
         // given
         TokenDto tokens = TokenDto.builder()
@@ -68,7 +76,7 @@ class KakaoLoginControllerTest {
 
         // then
         mvc.perform(get("/refresh")
-                .header("Authorization", "oldRefreshToken"))
+                        .header("Authorization", "oldRefreshToken"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.status", equalTo(200)))
                 .andExpect(jsonPath("$.result", equalTo(true)))
@@ -78,14 +86,9 @@ class KakaoLoginControllerTest {
     }
 
     @Test
-    @DisplayName("리프레시 토큰 갱신시 서버의 토큰과 일치하지 않을 경우 예외 발생 테스트")
+    @DisplayName("JWT 토큰 갱신시 요청한 리프레시 토큰과 서버의 리프레시 토큰과 일치하지 않을 경우 예외 발생 테스트")
     void refreshFailRefreshTokenNotMatch() throws Exception {
         // given
-        TokenDto tokens = TokenDto.builder()
-                .accessToken("accessToken")
-                .refreshToken("refreshToken")
-                .build();
-
         // when
         doThrow(RefreshTokenNotMatchException.class).when(loginService).refresh(anyString());
 
@@ -96,6 +99,38 @@ class KakaoLoginControllerTest {
                 .andExpect(jsonPath("$.status", equalTo(401)))
                 .andExpect(jsonPath("$.result", equalTo(false)))
                 .andExpect(jsonPath("$.message", equalTo(REFRESH_TOKEN_NOT_MATCH.getMessage())))
+                .andExpect(jsonPath("$.data", equalTo(null)));
+    }
+
+    @Test
+    @DisplayName("카카오 및 서비스 회원 탈퇴 테스트")
+    void withdraw() throws Exception {
+        // given
+        doNothing().when(loginService).withdraw(anyLong());
+
+        // when
+        // then
+        mvc.perform(post("/withdraw")
+                .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(jsonPath("$.status", equalTo(200)))
+                .andExpect(jsonPath("$.result", equalTo(true)))
+                .andExpect(jsonPath("$.message", equalTo(WITHDRAW_SUCCESS.getMessage())))
+                .andExpect(jsonPath("$.data", equalTo(null)));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원이 회원탈퇴 요청을 한경우")
+    void withdrawFailMemberNotFound() throws Exception {
+        // given
+        doThrow(MemberNotFoundException.class).when(loginService).withdraw(anyLong());
+
+        // when
+        // then
+        mvc.perform(post("/withdraw")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(jsonPath("$.status", equalTo(401)))
+                .andExpect(jsonPath("$.result", equalTo(false)))
+                .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
                 .andExpect(jsonPath("$.data", equalTo(null)));
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/KakaoServiceTest.java
@@ -5,21 +5,15 @@ import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.K
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
 import com.carrot.carrotmarketclonecoding.auth.dto.KakaoTokenResponseDto;
 import com.carrot.carrotmarketclonecoding.auth.dto.KakaoUserInfoResponseDto;
-import com.carrot.carrotmarketclonecoding.auth.dto.LoginRespDto;
 import com.carrot.carrotmarketclonecoding.common.exception.KakaoTokenNotExistsException;
 import com.carrot.carrotmarketclonecoding.common.exception.KakaoUserInfoNotExistsException;
-import com.carrot.carrotmarketclonecoding.member.domain.Member;
-import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
-import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import java.util.HashMap;
-import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,15 +22,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 class KakaoServiceTest {
 
     @InjectMocks
     private KakaoService kakaoService;
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @Mock
     private RestTemplate restTemplate;
@@ -111,44 +103,31 @@ class KakaoServiceTest {
     }
 
     @Test
-    @DisplayName("존재하는 회원일경우 회원가입 테스트")
-    void joinWhenMemberAlreadyExists() {
+    @DisplayName("카카오 로그아웃 테스트")
+    void logoutSuccess() throws Exception {
         // given
         Long authId = 1111L;
-        Member member = Member.builder()
-                .authId(authId)
-                .role(Role.USER)
-                .build();
-
-        KakaoUserInfoResponseDto userInfo = createMockKakaoUserInfoResponseDto();
-
-        when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(member));
+        when(restTemplate.exchange(anyString(), any(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(new ObjectMapper().writeValueAsString(authId)));
 
         // when
-        LoginRespDto loginResponse = kakaoService.join(userInfo);
+        kakaoService.logout(authId);
 
         // then
-        assertThat(loginResponse.getAuthId()).isEqualTo(authId);
-        assertThat(loginResponse.getRole()).isEqualTo(Role.USER);
     }
 
     @Test
-    @DisplayName("존재하지않는 회원일경우 회원가입 테스트")
-    void joinWhenMemberNotExists() {
+    @DisplayName("카카오 연결해제 테스트")
+    void unlinkSuccess() throws Exception {
         // given
         Long authId = 1111L;
-
-        KakaoUserInfoResponseDto userInfo = createMockKakaoUserInfoResponseDto();
-
-        when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
-        when(memberRepository.save(any())).thenReturn(Member.builder().authId(authId).role(Role.USER).build());
+        when(restTemplate.exchange(anyString(), any(), any(), eq(String.class)))
+                .thenReturn(ResponseEntity.ok(new ObjectMapper().writeValueAsString(authId)));
 
         // when
-        LoginRespDto loginResponse = kakaoService.join(userInfo);
+        kakaoService.unlink(authId);
 
         // then
-        assertThat(loginResponse.getAuthId()).isEqualTo(authId);
-        assertThat(loginResponse.getRole()).isEqualTo(Role.USER);
     }
 
     private KakaoUserInfoResponseDto createMockKakaoUserInfoResponseDto() {

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LogoutHandlerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LogoutHandlerTest.java
@@ -1,12 +1,11 @@
 package com.carrot.carrotmarketclonecoding.auth.service;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.auth.handler.LogoutHandlerImpl;
 import com.carrot.carrotmarketclonecoding.auth.util.JwtUtil;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,7 +25,7 @@ class LogoutHandlerTest {
     private JwtUtil jwtUtil;
 
     @Mock
-    private RefreshTokenRedisService redisService;
+    private LoginService loginService;
 
     @Mock
     private Authentication authentication;
@@ -41,11 +40,11 @@ class LogoutHandlerTest {
     private LogoutHandlerImpl logoutHandler;
 
     @Test
-    @DisplayName("로그아웃 요청 시 리프레시 토큰 삭제 테스트")
+    @DisplayName("로그아웃 핸들러 동작 테스트")
     void logoutSuccess() {
         // given
-        String token = "token";
         Long authId = 1111L;
+        String token = "token";
         when(request.getHeader(anyString())).thenReturn(token);
         when(jwtUtil.verify(anyString())).thenReturn(new LoginUser(Member.builder().authId(authId).build()));
 
@@ -54,6 +53,6 @@ class LogoutHandlerTest {
 
         // then
         verify(jwtUtil).verify(token);
-        verify(redisService).deleteRefreshToken(authId);
+        verify(loginService).logout(authId);
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LogoutSuccessHandlerImplTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/auth/service/LogoutSuccessHandlerImplTest.java
@@ -3,6 +3,7 @@ package com.carrot.carrotmarketclonecoding.auth.service;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockStatic;
 
+import com.carrot.carrotmarketclonecoding.auth.handler.LogoutSuccessHandlerImpl;
 import com.carrot.carrotmarketclonecoding.auth.util.ResponseUtil;
 import com.carrot.carrotmarketclonecoding.common.response.SuccessMessage;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,6 +28,7 @@ s3:
 
 kakao:
   client_id: ENC(3lReUAOOcDY3yjrs6RSPlfC4b4axnlefsmQbitKNXlt0QtmGxTmqcjRRP462SRox)
+  admin-key: ENC(XX6kopdlBAf5/uJgp2P8qWu1nDjxQ3wL+UWnWFA8zm5BDas5s1PI7lPYO7wnJZf1)
 
 jwt:
   secret: ENC(AZSMHtQVuCDzJNRt1ln9wKpeKm13cB6U9zIp23MOjjyBNIOqa+X7lMeAo8ki+bmW)


### PR DESCRIPTION
## 구현 기능
- [x] 카카오 연결해제 로직 구현
- [x] 로그아웃 실행시 카카오 서버로 로그아웃 요청
- [x] Member 테이블에서 withdraw 필드 삭제 (회원탈퇴시 관련된 Board, BoardLike 데이터 모두 삭제)

## 관련 이슈
resolved #74 