### PR TITLE
게시글 조회 로직 수정

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/auth/controller/KakaoLoginController.java
@@ -8,7 +8,6 @@ import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
 import com.carrot.carrotmarketclonecoding.auth.dto.TokenDto;
 import com.carrot.carrotmarketclonecoding.auth.service.LoginService;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -48,18 +47,5 @@ public class KakaoLoginController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, WITHDRAW_SUCCESS.getMessage(), null));
-    }
-
-    @GetMapping("/test")
-    public ResponseEntity<?> test(HttpServletRequest request) {
-        String ip = request.getHeader("X-Forwarded-For");
-        if (ip == null || ip.length() == 0 || "unknown".equalsIgnoreCase(ip)) {
-            ip = request.getRemoteAddr();
-        }
-
-        log.info("IP : {}", ip);
-        log.info("USER AGENT : {}", request.getHeader("User-Agent"));
-
-        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -18,7 +18,7 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearch
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
-import jakarta.servlet.http.HttpSession;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -61,8 +61,8 @@ public class BoardController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<?> detail(@PathVariable("id") Long boardId, HttpSession session) {
-        BoardDetailResponseDto boardDetail = boardService.detail(boardId, session.getId());
+    public ResponseEntity<?> detail(@PathVariable("id") Long boardId, HttpServletRequest request) {
+        BoardDetailResponseDto boardDetail = boardService.detail(boardId, request);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_DETAIL_SUCCESS.getMessage(), boardDetail));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -7,12 +7,13 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearc
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.data.domain.Pageable;
 
 public interface BoardService {
     Long register(BoardRegisterRequestDto registerRequestDto, Long authId, boolean tmp);
 
-    BoardDetailResponseDto detail(Long boardId, String sessionId);
+    BoardDetailResponseDto detail(Long boardId, HttpServletRequest request);
 
     BoardDetailResponseDto tmpBoardDetail(Long memberId);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitRedisService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitRedisService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class VisitService {
+public class VisitRedisService {
     private final RedisTemplate<String, String> redisTemplate;
 
     private static final String BOARD_VISIT_KEY_PREFIX = "viewed:";

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/VisitService.java
@@ -10,20 +10,20 @@ import org.springframework.stereotype.Service;
 public class VisitService {
     private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String BOARD_VISIT_KEY_PREFIX = "board:visit:";
+    private static final String BOARD_VISIT_KEY_PREFIX = "viewed:";
 
-    public boolean increaseVisit(String boardId, String sessionId) {
-        String sessionKey = BOARD_VISIT_KEY_PREFIX + boardId + ":session:" + sessionId;
-        Boolean viewed = redisTemplate.hasKey(sessionKey);
-        if (sessionId != null && sessionId.length() > 0) {
-            return setSessionKey(viewed, sessionKey);
+    public boolean increaseVisit(String boardId, String ip, String userAgent) {
+        String key = BOARD_VISIT_KEY_PREFIX + boardId + ":" + ip + ":" + userAgent;
+        Boolean viewed = redisTemplate.hasKey(key);
+        if (ip != null && ip.length() > 0 && userAgent != null && userAgent.length() > 0) {
+            return setVisitData(viewed, key);
         }
         return false;
     }
 
-    private boolean setSessionKey(Boolean viewed, String sessionKey) {
+    private boolean setVisitData(Boolean viewed, String key) {
         if (viewed != null && !viewed) {
-            redisTemplate.opsForValue().set(sessionKey, "1", 24, TimeUnit.HOURS);
+            redisTemplate.opsForValue().set(key, "1", 24, TimeUnit.HOURS);
             return true;
         }
         return false;

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -14,7 +14,7 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordRedisService;
-import com.carrot.carrotmarketclonecoding.board.service.VisitService;
+import com.carrot.carrotmarketclonecoding.board.service.VisitRedisService;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
@@ -40,7 +40,7 @@ public class BoardServiceImpl implements BoardService {
     private final CategoryRepository categoryRepository;
     private final BoardPictureRepository boardPictureRepository;
     private final BoardLikeRepository boardLikeRepository;
-    private final VisitService visitService;
+    private final VisitRedisService visitRedisService;
     private final BoardPictureService boardPictureService;
     private final SearchKeywordRedisService searchKeywordRedisService;
 
@@ -66,7 +66,7 @@ public class BoardServiceImpl implements BoardService {
         log.debug("IP: {}", ip);
         log.debug("USER-AGENT: {}", userAgent);
 
-        if (visitService.increaseVisit(board.getId().toString(), ip, userAgent)) {
+        if (visitRedisService.increaseVisit(board.getId().toString(), ip, userAgent)) {
             board.increaseVisit();
         }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -30,4 +30,4 @@ server:
 serverName: localhost
 logging:
   level:
-    com.carrot.carrotmarketclonecoding.auth: DEBUG
+    com.carrot.carrotmarketclonecoding: DEBUG

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -253,7 +252,7 @@ class BoardControllerTest {
                     .build();
 
             // when
-            when(boardService.detail(anyLong(), anyString())).thenReturn(response);
+            when(boardService.detail(anyLong(), any())).thenReturn(response);
 
             // then
             mvc.perform(get("/board/{id}", boardId))
@@ -270,7 +269,7 @@ class BoardControllerTest {
             // given
 
             // when
-            when(boardService.detail(anyLong(), anyString())).thenThrow(new BoardNotFoundException());
+            when(boardService.detail(anyLong(), any())).thenThrow(new BoardNotFoundException());
 
             // then
             mvc.perform(get("/board/{id}", 1L))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -32,6 +32,7 @@ import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessExc
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -80,6 +81,9 @@ class BoardServiceTest {
 
     @Mock
     private SearchKeywordRedisService searchKeywordRedisService;
+
+    @Mock
+    private HttpServletRequest request;
 
     @Nested
     @DisplayName(BOARD_REGISTER_SERVICE_TEST)
@@ -219,7 +223,6 @@ class BoardServiceTest {
             // given
             Long boardId = 1L;
             Long memberId = 1L;
-            String sessionId = "session:" + memberId;
             List<BoardPicture> mockPictures = Arrays.asList(
                     BoardPicture.builder().id(1L).build(),
                     BoardPicture.builder().id(2L).build());
@@ -227,10 +230,10 @@ class BoardServiceTest {
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
-            when(visitService.increaseVisit(anyString(), anyString())).thenReturn(true);
+            when(visitService.increaseVisit(anyString(), any(), any())).thenReturn(true);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, sessionId);
+            BoardDetailResponseDto result = boardService.detail(boardId, request);
 
             // then
             assertThat(result.getId()).isEqualTo(boardId);
@@ -259,10 +262,10 @@ class BoardServiceTest {
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
-            when(visitService.increaseVisit(anyString(), anyString())).thenReturn(false);
+            when(visitService.increaseVisit(anyString(), any(), any())).thenReturn(false);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, "sessionId:" + memberId);
+            BoardDetailResponseDto result = boardService.detail(boardId, request);
 
             // then
             assertThat(result.getVisit()).isEqualTo(10);
@@ -278,7 +281,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.detail(boardId, "sessionId:" + memberId))
+            assertThatThrownBy(() -> boardService.detail(boardId, request))
                     .isInstanceOf(BoardNotFoundException.class)
                     .hasMessage(BOARD_NOT_FOUND.getMessage());
         }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -74,7 +74,7 @@ class BoardServiceTest {
     private BoardLikeRepository boardLikeRepository;
 
     @Mock
-    private VisitService visitService;
+    private VisitRedisService visitRedisService;
 
     @Mock
     private BoardPictureService boardPictureService;
@@ -230,7 +230,7 @@ class BoardServiceTest {
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
-            when(visitService.increaseVisit(anyString(), any(), any())).thenReturn(true);
+            when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(true);
 
             // when
             BoardDetailResponseDto result = boardService.detail(boardId, request);
@@ -262,7 +262,7 @@ class BoardServiceTest {
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
-            when(visitService.increaseVisit(anyString(), any(), any())).thenReturn(false);
+            when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(false);
 
             // when
             BoardDetailResponseDto result = boardService.detail(boardId, request);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/VisitRedisServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/VisitRedisServiceTest.java
@@ -15,7 +15,7 @@ import org.springframework.test.context.ActiveProfiles;
 @ActiveProfiles("test")
 @DataRedisTest
 @ExtendWith(RedisContainerConfig.class)
-class VisitServiceTest {
+class VisitRedisServiceTest {
 
     @Autowired
     private RedisTemplate<String, String> redisTemplate;


### PR DESCRIPTION
## 구현 기능
- [x] 기존 세션 아이디로 게시글 조회 이력 저장 방식에서 사용자의 IP, 브라우저 종류를 사용하여 저장하는 방식으로 변경
- [x] 로컬 yml 디버그 로그 출력하도록 수정
- [x] x-Forwarded-For, User-Agent 헤더 테스트 API 삭제
- [x] 조회수 관련 테스트 로직 수정
- [ ] VisitService 클래스명 수정

## 관련 이슈
resolved #89 