### PR TITLE
프로필 수정 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -29,7 +29,9 @@ public enum SuccessMessage {
     LOGIN_SUCCESS("로그인에 성공하였습니다!"),
     RECREATE_TOKENS_SUCCESS("토큰 재발급에 성공하였습니다!"),
     LOGOUT_SUCCESS("로그아웃에 성공하였습니다!"),
-    WITHDRAW_SUCCESS("회원탈퇴에 성공하였습니다!");
+    WITHDRAW_SUCCESS("회원탈퇴에 성공하였습니다!"),
+
+    PROFILE_UPDATE_SUCCESS("프로필 수정에 성공하였습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/controller/MemberController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/controller/MemberController.java
@@ -1,0 +1,33 @@
+package com.carrot.carrotmarketclonecoding.member.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.PROFILE_UPDATE_SUCCESS;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileRequestDto.ProfileUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/profile")
+@RequiredArgsConstructor
+public class MemberController {
+    private final MemberService memberService;
+
+    @PatchMapping
+    public ResponseEntity<?> update(@AuthenticationPrincipal LoginUser loginUser, @ModelAttribute ProfileUpdateRequestDto profileUpdateRequestDto) {
+        Long authId = Long.parseLong(loginUser.getUsername());
+        memberService.update(authId, profileUpdateRequestDto);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, PROFILE_UPDATE_SUCCESS.getMessage(), null));
+    }
+
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.carrot.carrotmarketclonecoding.member.domain;
 
 import com.carrot.carrotmarketclonecoding.common.BaseEntity;
 import com.carrot.carrotmarketclonecoding.member.domain.enums.Role;
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileRequestDto.ProfileUpdateRequestDto;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -31,4 +32,13 @@ public class Member extends BaseEntity {
     private Role role;
 
     private Long authId;
+
+    public void updateProfile(String nickname, String profileUrl) {
+        if (nickname != null && nickname.length() > 0) {
+            this.nickname = nickname;
+        }
+        if (profileUrl != null && profileUrl.length() > 0) {
+            this.profileUrl = profileUrl;
+        }
+    }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/dto/ProfileRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/dto/ProfileRequestDto.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.member.dto;
+
+import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
+
+public class ProfileRequestDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileUpdateRequestDto {
+        private MultipartFile profileImage;
+        private String nickname;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/service/MemberService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/service/MemberService.java
@@ -1,0 +1,7 @@
+package com.carrot.carrotmarketclonecoding.member.service;
+
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileRequestDto.ProfileUpdateRequestDto;
+
+public interface MemberService {
+    void update(Long authId, ProfileUpdateRequestDto profileUpdateRequestDto);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceImpl.java
@@ -1,0 +1,36 @@
+package com.carrot.carrotmarketclonecoding.member.service.impl;
+
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.file.service.FileService;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileRequestDto.ProfileUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import com.carrot.carrotmarketclonecoding.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+    private final MemberRepository memberRepository;
+    private final FileService fileService;
+
+    @Override
+    public void update(Long authId, ProfileUpdateRequestDto profileUpdateRequestDto) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+
+        fileService.deleteUploadedImage(member.getProfileUrl());
+        String profileUrl = null;
+        if (profileUpdateRequestDto.getProfileImage() != null) {
+            profileUrl = fileService.uploadImage(profileUpdateRequestDto.getProfileImage());
+        }
+
+        log.debug("new nickname: {}", profileUpdateRequestDto.getNickname());
+        log.debug("profileUrl: {}", profileUrl);
+
+        member.updateProfile(profileUpdateRequestDto.getNickname(), profileUrl);
+        memberRepository.save(member);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/controller/MemberControllerTest.java
@@ -1,0 +1,102 @@
+package com.carrot.carrotmarketclonecoding.member.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.PROFILE_UPDATE_SUCCESS;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.member.service.impl.MemberServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WithCustomMockUser
+@WebMvcTest(controllers = MemberController.class)
+class MemberControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private MemberServiceImpl memberService;
+
+    @Nested
+    @DisplayName("프로필 업데이트 테스트")
+    class ProfileUpdate {
+
+        @Test
+        @DisplayName("성공")
+        void updateSuccess() throws Exception {
+            // given
+            MockMultipartFile profileImage = new MockMultipartFile(
+                    "profileImage",
+                    "picture.png",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "picture".getBytes());
+
+            // when
+            doNothing().when(memberService).update(anyLong(), any());
+
+            // then
+            mvc.perform(multipart("/profile")
+                            .file(profileImage)
+                            .param("nickname", "newNickname")
+                            .with(request -> {
+                                request.setMethod("PATCH");
+                                return request;
+                            })
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .contentType(MediaType.MULTIPART_FORM_DATA))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.status", equalTo(200)))
+                    .andExpect(jsonPath("$.result", equalTo(true)))
+                    .andExpect(jsonPath("$.message", equalTo(PROFILE_UPDATE_SUCCESS.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자가 존재하지 않음")
+        void updateFailMemberNotFound() throws Exception {
+            // given
+            MockMultipartFile profileImage = new MockMultipartFile(
+                    "profileImage",
+                    "picture.png",
+                    MediaType.IMAGE_JPEG_VALUE,
+                    "picture".getBytes());
+
+            // when
+            doThrow(MemberNotFoundException.class).when(memberService).update(anyLong(), any());
+
+            // then
+            mvc.perform(multipart("/profile")
+                            .file(profileImage)
+                            .param("nickname", "newNickname")
+                            .with(request -> {
+                                request.setMethod("PATCH");
+                                return request;
+                            })
+                            .with(SecurityMockMvcRequestPostProcessors.csrf())
+                            .contentType(MediaType.MULTIPART_FORM_DATA))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.status", equalTo(401)))
+                    .andExpect(jsonPath("$.result", equalTo(false)))
+                    .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
+                    .andExpect(jsonPath("$.data", equalTo(null)));
+        }
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceTest.java
@@ -1,0 +1,94 @@
+package com.carrot.carrotmarketclonecoding.member.service.impl;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.file.service.impl.FileServiceImpl;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileRequestDto.ProfileUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class MemberServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private FileServiceImpl fileService;
+
+    @InjectMocks
+    private MemberServiceImpl memberService;
+
+    @Nested
+    @DisplayName("프로필 업데이트 테스트")
+    class ProfileUpdate {
+
+        @Test
+        @DisplayName("성공")
+        void updateSuccess() {
+            // given
+            Member mockMember = Member.builder()
+                    .authId(1111L)
+                    .nickname("oldNickname")
+                    .profileUrl("oldProfileUrl")
+                    .build();
+
+            ProfileUpdateRequestDto profileUpdateRequestDto = ProfileUpdateRequestDto.builder()
+                    .nickname("newNickname")
+                    .profileImage(new MockMultipartFile(
+                            "file",
+                            "file.png",
+                            "text/png",
+                            ("Picture").getBytes()))
+                    .build();
+
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
+            doNothing().when(fileService).deleteUploadedImage(anyString());
+            when(fileService.uploadImage(any())).thenReturn("newProfileUrl");
+
+            ArgumentCaptor<Member> argumentCaptor = ArgumentCaptor.forClass(Member.class);
+
+            // when
+            memberService.update(1111L, profileUpdateRequestDto);
+
+            // then
+            verify(memberRepository).save(argumentCaptor.capture());
+            Member member = argumentCaptor.getValue();
+            assertThat(member.getAuthId()).isEqualTo(1111L);
+            assertThat(member.getNickname()).isEqualTo("newNickname");
+            assertThat(member.getProfileUrl()).isEqualTo("newProfileUrl");
+        }
+
+        @Test
+        @DisplayName("실패 - 사용자가 존재하지 않음")
+        void updateFailMemberNotFound() {
+            // given
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> memberService.update(1111L, new ProfileUpdateRequestDto()))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 구현 기능
사용자의 프로필 수정 기능 구현
- [x] 사용자의 닉네임, 프로필 수정
- [x] 기존 S3 이미지 URL이 있을 경우 S3에서 삭제 후 새 이미지 업로드 후 새 URL로 수정
- [x] 프로필 수정 서비스, 컨트롤러 단 테스트 케이스 추가

## 관련 이슈
resolved #73 