### PR TITLE
SSE 응답 API 헤더 설정

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
 import com.carrot.carrotmarketclonecoding.notification.dto.NotificationResponseDto;
 import com.carrot.carrotmarketclonecoding.notification.service.SseEmitterService;
 import com.carrot.carrotmarketclonecoding.notification.service.impl.NotificationServiceImpl;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,9 @@ public class NotificationController {
     private final SseEmitterService sseEmitterService;
     private final NotificationServiceImpl notificationService;
 
+    private static final String X_ACCEL_BUFFERING = "X-Accel-Buffering";
+    private static final String X_ACCEL_BUFFERING_VALUE = "no";
+
     @GetMapping("/notification")
     public ResponseEntity<?> getAllNotifications(@AuthenticationPrincipal LoginUser loginUser) {
         List<NotificationResponseDto> notifications =
@@ -33,7 +37,9 @@ public class NotificationController {
     }
 
     @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal LoginUser loginUser) {
+    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal LoginUser loginUser, HttpServletResponse response) {
+        response.setHeader(X_ACCEL_BUFFERING, X_ACCEL_BUFFERING_VALUE);
+
         Long id = Long.parseLong(loginUser.getUsername());
         return ResponseEntity.ok(sseEmitterService.add(id));
     }


### PR DESCRIPTION
## 구현 기능
Nginx 서버의 `proxy-buffering-off` 설정으로 인해 Proxy Buffering을 비활성화 해놓은 상태.
SSE 응답 API의 X-Accel 헤더 값을 NO로 응답해 버퍼링을 사용하지 않도록 설정.
<br/>

## 관련 이슈
resolved #104 