### PR TITLE
클라이언트에서 전달받지 못한 이전 실시간알림 내용 전송 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardLikeServiceImpl.java
@@ -29,7 +29,7 @@ public class BoardLikeServiceImpl implements BoardLikeService {
     private final MemberRepository memberRepository;
     private final NotificationService notificationService;
 
-    private static final String SSE_LIKE_CONTENT = "%s님이 %s님의 게시글을 좋아하였습니다!";
+    private static final String SSE_LIKE_CONTENT = "%s님이 %s님의 %d번 게시글을 좋아하였습니다!";
 
     @Override
     public void add(Long boardId, Long authId) {
@@ -48,7 +48,7 @@ public class BoardLikeServiceImpl implements BoardLikeService {
 
         Long targetAuthId = board.getMember().getAuthId();
         String targetNickname = board.getMember().getNickname();
-        String content = String.format(SSE_LIKE_CONTENT, member.getNickname(), targetNickname);
+        String content = String.format(SSE_LIKE_CONTENT, member.getNickname(), targetNickname, board.getId());
         notificationService.add(targetAuthId, NotificationType.LIKE, content);
     }
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationController.java
@@ -15,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -37,11 +38,12 @@ public class NotificationController {
     }
 
     @GetMapping(value = "/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal LoginUser loginUser, HttpServletResponse response) {
+    public ResponseEntity<SseEmitter> connect(@AuthenticationPrincipal LoginUser loginUser,
+                                              HttpServletResponse response,
+                                              @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
         response.setHeader(X_ACCEL_BUFFERING, X_ACCEL_BUFFERING_VALUE);
-
         Long id = Long.parseLong(loginUser.getUsername());
-        return ResponseEntity.ok(sseEmitterService.add(id));
+        return ResponseEntity.ok(sseEmitterService.subscribe(id, lastEventId));
     }
 
     // TODO 읽음처리

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/domain/enums/NotificationType.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/domain/enums/NotificationType.java
@@ -1,5 +1,5 @@
 package com.carrot.carrotmarketclonecoding.notification.domain.enums;
 
 public enum NotificationType {
-    NOTICE, LIKE, KEYWORD
+    NOTICE, LIKE, KEYWORD, CONNECT, LAST_EVENT
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/repository/SseEmitterRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/repository/SseEmitterRepository.java
@@ -1,0 +1,20 @@
+package com.carrot.carrotmarketclonecoding.notification.repository;
+
+import java.util.Map;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+public interface SseEmitterRepository {
+    SseEmitter save(String emitterId, SseEmitter sseEmitter);
+
+    void saveEventCache(String emitterId, Object event);
+
+    Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId);
+
+    Map<String,Object> findAllEventCacheStartWithByMemberId(String memberId);
+
+    void deleteById(String emitterId);
+
+    void deleteAllEmitterStartWithId(String memberId);
+
+    void deleteAllEventCacheStartWithId(String memberId);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/repository/impl/SseEmitterRepositoryImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/repository/impl/SseEmitterRepositoryImpl.java
@@ -1,0 +1,67 @@
+package com.carrot.carrotmarketclonecoding.notification.repository.impl;
+
+import com.carrot.carrotmarketclonecoding.notification.repository.SseEmitterRepository;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Repository
+public class SseEmitterRepositoryImpl implements SseEmitterRepository {
+
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, Object> eventCache = new ConcurrentHashMap<>();
+
+    @Override
+    public SseEmitter save(String emitterId, SseEmitter sseEmitter) {
+        emitters.put(emitterId,sseEmitter);
+        return sseEmitter;
+    }
+
+    @Override
+    public void saveEventCache(String emitterId, Object event) {
+        eventCache.put(emitterId,event);
+    }
+
+    @Override
+    public Map<String, SseEmitter> findAllEmitterStartWithByMemberId(String memberId) {
+        return emitters.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public Map<String, Object> findAllEventCacheStartWithByMemberId(String memberId) {
+        return eventCache.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(memberId))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @Override
+    public void deleteById(String emitterId) {
+        emitters.remove(emitterId);
+    }
+
+    @Override
+    public void deleteAllEmitterStartWithId(String memberId) {
+        emitters.forEach(
+                (key,emitter) -> {
+                    if(key.startsWith(memberId)){
+                        emitters.remove(key);
+                    }
+                }
+        );
+    }
+
+    @Override
+    public void deleteAllEventCacheStartWithId(String memberId) {
+        eventCache.forEach(
+                (key,emitter) -> {
+                    if(key.startsWith(memberId)){
+                        eventCache.remove(key);
+                    }
+                }
+        );
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/SseEmitterService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/SseEmitterService.java
@@ -1,9 +1,10 @@
 package com.carrot.carrotmarketclonecoding.notification.service;
 
 import com.carrot.carrotmarketclonecoding.notification.domain.enums.NotificationType;
+import com.carrot.carrotmarketclonecoding.notification.repository.SseEmitterRepository;
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -11,52 +12,84 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class SseEmitterService {
+
+    private final SseEmitterRepository emitterRepository;
 
     @Value("${sse.timeout}")
     private Long timeout;
 
-    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private static final String CONNECT_MESSAGE = "connected!";
 
-    public SseEmitter add(Long authId) {
+    public SseEmitter subscribe(Long authId, String lastEventId) {
+        emitterRepository.deleteAllEmitterStartWithId(String.valueOf(authId));
+
+        String emitterId = createEmitterId(authId);
         SseEmitter emitter = new SseEmitter(timeout);
-        this.emitters.put(authId, emitter);
+        emitterRepository.save(emitterId, emitter);
+        sendToClient(emitter, emitterId, NotificationType.CONNECT, CONNECT_MESSAGE);
 
-        log.debug("Sending Dummy Data...");
-        send(authId, NotificationType.NOTICE, "connected!");
-
-        log.debug("SSE EMITTER -> authID: {}, emitter: {}, size: {}", authId, emitter, emitters.size());
+        log.debug("emitterId: {}", emitterId);
 
         emitter.onCompletion(() -> {
-            log.debug("SseEmitter onCompletion callback");
-            this.emitters.remove(authId);
+            log.debug(">> SseEmitter onCompletion callback");
+            emitterRepository.deleteById(emitterId);
         });
 
         emitter.onTimeout(() -> {
-            log.debug("SseEmitter onTimeout callback");
+            log.debug(">> SseEmitter onTimeout callback");
+            emitterRepository.deleteById(emitterId);
             emitter.complete();
         });
 
         emitter.onError(throwable -> {
-            log.debug("SseEmitter Error occurred!");
+            log.debug(">> SseEmitter Error occurred!");
+            emitterRepository.deleteById(emitterId);
             emitter.complete();
         });
+
+        sendAfterLastEventId(authId, lastEventId, emitter);
 
         return emitter;
     }
 
-    public void send(Long id, NotificationType type, String content) {
-        log.debug("Map에 저장되어 있는가? {}", emitters.containsKey(id));
-        SseEmitter emitter = emitters.get(id);
-        log.debug("저장되어 있는 emitter 정보 : {}", emitter.toString());
+    public void send(Long authId, NotificationType type, Object content) {
+        Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByMemberId(String.valueOf(authId));
+        sseEmitters.forEach(
+                (key, emitter) -> {
+                    String emitterId = createEmitterId(authId);
+                    emitterRepository.saveEventCache(emitterId, content);
+                    sendToClient(emitter, emitterId, type, content);
+                }
+        );
+    }
+
+    private void sendToClient(SseEmitter emitter, String emitterId, NotificationType type, Object data) {
         try {
-            log.debug("알림을 전송합니다!");
+            log.debug("알림을 전송합니다! -> {}", emitterId);
             emitter.send(SseEmitter.event()
+                    .id(emitterId)
                     .name(type.name())
-                    .data(content));
-        } catch (IOException e) {
-            log.error("알림 전송에 실패하였습니다!");
-            throw new RuntimeException(e);
+                    .data(data));
+        } catch (IOException exception) {
+            log.debug("알림 전송중 에러 발생...");
+            emitterRepository.deleteById(emitterId);
+        }
+    }
+
+    private String createEmitterId(Long authId) {
+        return authId + "_" + System.currentTimeMillis();
+    }
+
+    private void sendAfterLastEventId(Long authId, String lastEventId, SseEmitter emitter) {
+        if (!lastEventId.isEmpty()) {
+            log.debug("LastEventId: {}", lastEventId);
+            Map<String, Object> events = emitterRepository.findAllEventCacheStartWithByMemberId(String.valueOf(authId));
+            events.entrySet().stream()
+                    .filter(entry -> lastEventId.compareTo(entry.getKey()) < 0)
+                    .sorted(Map.Entry.comparingByKey())
+                    .forEach(entry -> sendToClient(emitter, entry.getKey(), NotificationType.LAST_EVENT, entry.getValue()));
         }
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardLikeServiceTest.java
@@ -80,7 +80,7 @@ class BoardLikeServiceTest {
                     .authId(memberId)
                     .nickname("member")
                     .build();
-            String content = String.format("%s님이 %s님의 게시글을 좋아하였습니다!", mockMember.getNickname(), mockBoard.getMember().getNickname());
+            String content = String.format("%s님이 %s님의 %d번 게시글을 좋아하였습니다!", mockMember.getNickname(), mockBoard.getMember().getNickname(), mockBoard.getId());
 
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));

--- a/src/test/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/notification/controller/NotificationControllerTest.java
@@ -3,6 +3,7 @@ package com.carrot.carrotmarketclonecoding.notification.controller;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.GET_ALL_NOTIFICATIONS_SUCCESS;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -41,7 +42,7 @@ class NotificationControllerTest {
     void connectSuccess() throws Exception {
         // given
         // when
-        when(sseEmitterService.add(anyLong())).thenReturn(mock(SseEmitter.class));
+        when(sseEmitterService.subscribe(anyLong(), anyString())).thenReturn(mock(SseEmitter.class));
 
         // then
         mvc.perform(get("/connect"))


### PR DESCRIPTION
## 구현 기능
- [x] 클라이언트에서 서버로 SSE를 재연결 요청할동안 알림이 전송될경우 수신하지 못함 -> 수신하지 못한 알림들을 재연결시 모두 전송
- [x] 클라이언트에서 `LastEventId` 헤더를 전달받음
- [x] SSE 연결시 LastEventId 이후에 생성된 알림을 캐시에서 읽어 전송
- [x] `SseEmitter`와 알림내용캐시를 저장하는 Map을 `SseEmitterRepository`를 생성하여 따로 관리
<br/>

## 관련 이슈
resolved #106 