### PR TITLE
이전알림조회, 실시간 알림 전송 응답 필드 추가

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/dto/NotificationResponseDto.java
@@ -15,6 +15,7 @@ public class NotificationResponseDto {
     private Long id;
     private String content;
     private NotificationType type;
+    private Boolean isRead;
     private LocalDateTime createDate;
     private LocalDateTime updateDate;
 
@@ -23,6 +24,7 @@ public class NotificationResponseDto {
                 .id(notification.getId())
                 .content(notification.getContent())
                 .type(notification.getType())
+                .isRead(notification.isRead())
                 .createDate(notification.getCreateDate())
                 .updateDate(notification.getUpdateDate())
                 .build();

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/impl/NotificationServiceImpl.java
@@ -32,7 +32,7 @@ public class NotificationServiceImpl implements NotificationService {
                 .isRead(false)
                 .build();
         notificationRepository.save(notification);
-        sseEmitterService.send(authId, NotificationType.LIKE, content);
+        sseEmitterService.send(authId, NotificationType.LIKE, NotificationResponseDto.createNotificationResponseDto(notification));
     }
 
     @Override


### PR DESCRIPTION
## 구현 기능
- [x] 이전 알림 내역 조회에서 isRead(읽음여부) 필드 추가
- [x] 실시간 알림 전송시 NotificationResponseDto 응답 객체 전송 -> 알림 읽음 처리 API에서 필요

## 관련 이슈
resolved #110 