### PR TITLE
키워드 알림 기능 구현

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
@@ -111,4 +111,29 @@ public class BoardResponseDto {
                     .build();
         }
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardNotificationResponseDto {
+        private Long id;
+        private String title;
+        private Integer price;
+        private String place;
+        private LocalDateTime createDate;
+        private String pictureUrl;
+
+        public BoardNotificationResponseDto(Board board) {
+            this.id = board.getId();
+            this.title = board.getTitle();
+            this.price = board.getPrice();
+            this.createDate = board.getCreateDate();
+
+            List<BoardPicture> boardPictures = board.getBoardPictures();
+            this.pictureUrl = boardPictures != null && boardPictures.size() > 0 ? boardPictures.get(0).getPictureUrl() : null;
+        }
+    }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/keyword/repository/KeywordRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/keyword/repository/KeywordRepository.java
@@ -3,10 +3,11 @@ package com.carrot.carrotmarketclonecoding.keyword.repository;
 import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.util.List;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface KeywordRepository extends JpaRepository<Keyword, Long> {
     int countByMember(Member member);
-
     List<Keyword> findAllByMember(Member member);
+    Set<Keyword> findByNameIn(Set<String> words);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/domain/Notification.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/domain/Notification.java
@@ -39,4 +39,11 @@ public class Notification extends BaseEntity {
     public void readNotification() {
         this.isRead = true;
     }
+
+    public Notification(Member member, String content, NotificationType type) {
+        this.member = member;
+        this.content = content;
+        this.isRead = false;
+        this.type = type;
+    }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/NotificationService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/NotificationService.java
@@ -5,7 +5,7 @@ import com.carrot.carrotmarketclonecoding.notification.dto.NotificationResponseD
 import java.util.List;
 
 public interface NotificationService {
-    void add(Long authId, NotificationType type, String content);
+    void add(Long authId, NotificationType type, Object content);
 
     List<NotificationResponseDto> getAllNotifications(Long authId);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/impl/NotificationServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/notification/service/impl/NotificationServiceImpl.java
@@ -26,16 +26,11 @@ public class NotificationServiceImpl implements NotificationService {
     private final SseEmitterService sseEmitterService;
 
     @Override
-    public void add(Long authId, NotificationType type, String content) {
+    public void add(Long authId, NotificationType type, Object content) {
         Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
-        Notification notification = Notification.builder()
-                .member(member)
-                .content(content)
-                .type(type)
-                .isRead(false)
-                .build();
+        Notification notification = new Notification(member, String.valueOf(content), type);
         notificationRepository.save(notification);
-        sseEmitterService.send(authId, NotificationType.LIKE, NotificationResponseDto.createNotificationResponseDto(notification));
+        sseEmitterService.send(authId, type, NotificationResponseDto.createNotificationResponseDto(notification));
     }
 
     @Override

--- a/src/test/java/com/carrot/carrotmarketclonecoding/keyword/repository/KeywordRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/keyword/repository/KeywordRepositoryTest.java
@@ -6,7 +6,9 @@ import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -61,5 +63,28 @@ class KeywordRepositoryTest {
 
         // then
         assertThat(keywords.size()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("쿼리메서드 findByNameIn() 테스트")
+    void findByNameIn() {
+        // given
+        Set<String> words = new HashSet<>(Arrays.asList(
+             "keyword1", "keyword2", "keyword3"
+        ));
+
+        keywordRepository.saveAll(Arrays.asList(
+                Keyword.builder().name("keyword1").build(),
+                Keyword.builder().name("keyword2").build(),
+                Keyword.builder().name("keyword3").build(),
+                Keyword.builder().name("keyword4").build(),
+                Keyword.builder().name("keyword5").build()
+        ));
+
+        // when
+        Set<Keyword> keywords = keywordRepository.findByNameIn(words);
+
+        // then
+        assertThat(keywords.size()).isEqualTo(3);
     }
 }


### PR DESCRIPTION
## 구현 기능
- [x] 게시글 작성시 키워드 알림을 등록한 키워드를 포함하고 있는 경우 등록한 사용자에게 실시간으로 알림 전송
- 게시글의 본문 + 내용의 단어들을 중복을 제거해 Keyword 테이블에서 조회
- 각 Keyword를 등록한 사용자에게 알림 전송 및 알림 내용 저장

## 관련 이슈
resolved #117 