### PR TITLE
Board 관련 테스트 코드 리팩토링

### DIFF
--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerTestUtil.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerTestUtil.java
@@ -1,0 +1,29 @@
+package com.carrot.carrotmarketclonecoding.util;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+
+public class ControllerTestUtil {
+
+    protected MockHttpServletRequestBuilder requestWithCsrf(MockHttpServletRequestBuilder requestBuilder, MediaType contentType) {
+        if (contentType != null) {
+            requestBuilder.contentType(contentType);
+        }
+        return requestBuilder.with(SecurityMockMvcRequestPostProcessors.csrf());
+    }
+
+    protected ResultActions assertResult(ResultActions resultActions, ResultMatcher resultMatcher, int status, boolean result, String message, String dataExpression, Object data) throws Exception {
+        return resultActions
+                .andExpect(resultMatcher)
+                .andExpect(jsonPath("$.status", equalTo(status)))
+                .andExpect(jsonPath("$.result", equalTo(result)))
+                .andExpect(jsonPath("$.message", equalTo(message)))
+                .andExpect(jsonPath(dataExpression, equalTo(data)));
+    }
+}


### PR DESCRIPTION
## 구현 기능
- [x] Board 관련 테스트코드 리팩토링
  - [x] 테스트용 메서드 클래스 분리 -> `ControllerTestUtil.class` 상속해서 사용
- [x] 변수는 처음 사용하는 메서드 바로 전에 위치
- [x] 한번 사용하는 변수는 삭제


## 관련 이슈
resolved #124 