### PR TITLE
좋아요 관련 API 문서화

### DIFF
--- a/src/docs/asciidoc/board/boardLike.adoc
+++ b/src/docs/asciidoc/board/boardLike.adoc
@@ -1,0 +1,41 @@
+== BoardLike API
+
+=== 게시글 좋아요 등록
+
+==== CURL Request
+include::{snippets}/add-board-like/add-board-like-success/curl-request.adoc[]
+
+==== Path Parameters
+include::{snippets}/add-board-like/add-board-like-success/path-parameters.adoc[]
+
+==== Response Body (200 - 저장 성공)
+정상 응답
+include::{snippets}/add-board-like/add-board-like-success/response-fields.adoc[]
+include::{snippets}/add-board-like/add-board-like-success/response-body.adoc[]
+
+==== Response Body (400 - 등록할 게시글이 존재하지 않음)
+include::{snippets}/add-board-like/add-board-like-fail-board-not-found/response-body.adoc[]
+
+==== Response Body (401 - 존재하지 않는 사용자)
+include::{snippets}/add-board-like/add-board-like-fail-member-not-found/response-body.adoc[]
+
+==== Response Body (400 - 이미 좋아요한 게시글)
+include::{snippets}/add-board-like/add-board-like-fail-member-already-liked-board/response-body.adoc[]
+
+'''
+=== 내가 좋아요한 게시글 목록 조회
+
+==== CURL Request
+include::{snippets}/user-liked-boards/user-liked-boards-success/curl-request.adoc[]
+
+==== Parameters
+include::{snippets}/user-liked-boards/user-liked-boards-success/http-request.adoc[]
+include::{snippets}/user-liked-boards/user-liked-boards-success/query-parameters.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/user-liked-boards/user-liked-boards-success/response-fields.adoc[]
+include::{snippets}/user-liked-boards/user-liked-boards-success/response-body.adoc[]
+
+==== Response Body (401 - 존재하지 않는 사용자)
+include::{snippets}/user-liked-boards/user-liked-boards-fail-member-not-found/response-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -12,3 +12,5 @@ endif::[]
 
 include::board/board.adoc[]
 
+include::board/boardLike.adoc[]
+

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeDtoFactory.java
@@ -1,0 +1,34 @@
+package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
+
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class BoardLikeDtoFactory {
+
+    public List<BoardSearchResponseDto> createBoardSearchResponseDtos() {
+        return new ArrayList<>(Arrays.asList(
+                BoardSearchResponseDto.builder()
+                        .id(1L)
+                        .title("title")
+                        .pictureUrl("S3 Picture Url")
+                        .like(20)
+                        .price(20000)
+                        .place("Amsa")
+                        .createDate(LocalDateTime.now())
+                        .build(),
+                BoardSearchResponseDto.builder()
+                        .id(2L)
+                        .title("title2")
+                        .pictureUrl("S3 Picture Url2")
+                        .like(21)
+                        .price(40000)
+                        .place("Cheonho")
+                        .createDate(LocalDateTime.now())
+                        .build()));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRequestHelper.java
@@ -1,0 +1,25 @@
+package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@TestComponent
+public class BoardLikeRequestHelper {
+
+    private static final String ADD_BOARD_LIKE_URL = "/board/like/{id}";
+    private static final String GET_USER_LIKED_BOARDS_URL = "/board/like";
+
+    public ResultActions requestLikeBoard(MockMvc mvc) throws Exception {
+        return mvc.perform(post(ADD_BOARD_LIKE_URL, 1L)
+                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+    }
+
+    public ResultActions requestGetUserLikedBoards(MockMvc mvc) throws Exception {
+        return mvc.perform(get(GET_USER_LIKED_BOARDS_URL).param("page", "0"));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
@@ -1,0 +1,53 @@
+package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultHandler;
+
+@TestComponent
+public class BoardLikeRestDocsHelper extends RestDocsHelper {
+
+    public RestDocumentationResultHandler createAddBoardLikeDocument(RestDocumentationResultHandler restDocs) {
+        return restDocs.document(
+                pathParameters(parameterWithName("id").description("게시글 ID")),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    public ResultHandler createGetUserLikedBoardsSuccessDocument(RestDocumentationResultHandler restDocs) {
+        return restDocs.document(
+                queryParameters(
+                        parameterWithName("page").description("페이지번호")
+                ),
+                responseFields(
+                        createPageFieldsDescriptor(createContentsFieldDescriptor())
+                )
+        );
+    }
+
+    private FieldDescriptor[] createContentsFieldDescriptor() {
+        return new FieldDescriptor[] {
+                fieldWithPath("data.contents[].id").description("게시글 아이디"),
+                fieldWithPath("data.contents[].pictureUrl").description("사진 URL"),
+                fieldWithPath("data.contents[].title").description("게시글 제목"),
+                fieldWithPath("data.contents[].place").description("거래 장소"),
+                fieldWithPath("data.contents[].createDate").description("게시글 생성일"),
+                fieldWithPath("data.contents[].price").description("상품 가격"),
+                fieldWithPath("data.contents[].like").description("좋아요 수")
+        };
+    }
+
+    public ResultHandler createGetUserLikedBoardsFailedDocument(RestDocumentationResultHandler restDocs) {
+        return restDocs.document(
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeTestHelper.java
@@ -1,0 +1,60 @@
+package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@TestComponent
+public class BoardLikeTestHelper {
+
+    @Autowired
+    private BoardLikeRequestHelper requestHelper;
+
+    @Autowired
+    private BoardLikeRestDocsHelper docsHelper;
+
+    public void assertLikeBoard(MockMvc mvc, ResultFields resultFields, RestDocumentationResultHandler restDocs)
+            throws Exception {
+        assertResponseResult(requestHelper.requestLikeBoard(mvc), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createAddBoardLikeDocument(restDocs));
+    }
+
+    public void assertGetUserLikedBoardsSuccess(MockMvc mvc,
+                                                ResultFields resultFields,
+                                                RestDocumentationResultHandler restDocs)
+            throws Exception {
+        assertResponseResult(requestHelper.requestGetUserLikedBoards(mvc), resultFields)
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(2)))
+                .andExpect(jsonPath("$.data.totalPage", equalTo(1)))
+                .andExpect(jsonPath("$.data.totalElements", equalTo(2)))
+                .andExpect(jsonPath("$.data.first", equalTo(true)))
+                .andExpect(jsonPath("$.data.last", equalTo(true)))
+                .andExpect(jsonPath("$.data.numberOfElements", equalTo(2)))
+                .andDo(docsHelper.createGetUserLikedBoardsSuccessDocument(restDocs));
+    }
+
+    public void assertGetUserLikedBoardsFailed(MockMvc mvc,
+                                             ResultFields resultFields,
+                                             RestDocumentationResultHandler restDocs)
+            throws Exception{
+        assertResponseResult(requestHelper.requestGetUserLikedBoards(mvc), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createGetUserLikedBoardsFailedDocument(restDocs));
+    }
+
+    // TODO 분리
+    private ResultActions assertResponseResult(ResultActions resultActions, ResultFields resultFields) throws Exception {
+        return resultActions
+                .andExpect(resultFields.getResultMatcher())
+                .andExpect(jsonPath("$.status", equalTo(resultFields.getStatus())))
+                .andExpect(jsonPath("$.result", equalTo(resultFields.isResult())))
+                .andExpect(jsonPath("$.message", equalTo(resultFields.getMessage())));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsHelper.java
@@ -1,0 +1,37 @@
+package com.carrot.carrotmarketclonecoding.util;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.payload.FieldDescriptor;
+
+@TestComponent
+public class RestDocsHelper {
+
+    public FieldDescriptor[] createPageFieldsDescriptor(FieldDescriptor[] contentsDescriptors) {
+        List<FieldDescriptor> fieldDescriptors = new ArrayList<>(Arrays.asList(
+                fieldWithPath("status").description("응답 상태"),
+                fieldWithPath("result").description("응답 결과"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data.totalPage").description("전체 페이지 개수"),
+                fieldWithPath("data.totalElements").description("전체 데이터 수"),
+                fieldWithPath("data.first").description("첫페이지 여부"),
+                fieldWithPath("data.last").description("마지막페이지 여부"),
+                fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 개수")
+        ));
+        fieldDescriptors.addAll(Arrays.asList(contentsDescriptors));
+        return fieldDescriptors.toArray(new FieldDescriptor[0]);
+    }
+
+    public FieldDescriptor[] createResponseResultDescriptor() {
+        return new FieldDescriptor[] {
+                fieldWithPath("status").description("응답 상태"),
+                fieldWithPath("result").description("응답 결과"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data").description("응답 본문")
+        };
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsTestUtil.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsTestUtil.java
@@ -39,6 +39,7 @@ public class RestDocsTestUtil extends ControllerTestUtil {
                 .build();
     }
 
+    // TODO remove
     protected FieldDescriptor[] createResponseResultDescriptor() {
         return new FieldDescriptor[] {
                 fieldWithPath("status").description("응답 상태"),


### PR DESCRIPTION
## 구현 기능
- [x] Spring REST Docs 적용
- [x] BoardLikeControllerTest 리팩토링 -> MockMvc 요청, 테스트 검증, DTO 예시 객체 생성 메서드 각각 클래스로 분리 (SRP 최대한 적용)
- 테스트 패키지의 board.helper.boardlike 패키지에 생성

## 관련 이슈
resolved #128 