### PR TITLE
테스트 코드 리팩토링

### DIFF
--- a/src/docs/asciidoc/board/board.adoc
+++ b/src/docs/asciidoc/board/board.adoc
@@ -95,20 +95,20 @@ include::{snippets}/search-boards/search-boards-member-not-found/response-body.a
 
 === 내 게시글 검색
 ==== CURL Request
-include::{snippets}/search-board-by-status/search-boards-by-status-success/curl-request.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-success/curl-request.adoc[]
 
 ==== Http Request
-include::{snippets}/search-board-by-status/search-boards-by-status-success/http-request.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-success/http-request.adoc[]
 
 ==== Query Parameters
-include::{snippets}/search-board-by-status/search-boards-by-status-success/query-parameters.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-success/query-parameters.adoc[]
 
 ==== Response Body (200 - 성공)
-include::{snippets}/search-board-by-status/search-boards-by-status-success/response-fields.adoc[]
-include::{snippets}/search-board-by-status/search-boards-by-status-success/response-body.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-success/response-fields.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-success/response-body.adoc[]
 
 ==== Response Body (401 - 존재하지 않는 사용자)
-include::{snippets}/search-board-by-status/search-boards-by-status-fail-member-not-found/response-body.adoc[]
+include::{snippets}/search-my-boards/search-my-boards-fail-member-not-found/response-body.adoc[]
 
 '''
 
@@ -166,16 +166,16 @@ include::{snippets}/delete-board/delete-board-fail-member-is-not-writer/response
 
 === 임시저장한 게시글 조회
 ==== CURL Request
-include::{snippets}/tmp-board-detail/board-detail-success/curl-request.adoc[]
+include::{snippets}/get-tmp-board-detail/get-tmp-board-detail-success/curl-request.adoc[]
 
 ==== Http Request
-include::{snippets}/tmp-board-detail/board-detail-success/http-request.adoc[]
+include::{snippets}/get-tmp-board-detail/get-tmp-board-detail-success/http-request.adoc[]
 
 ==== Response Body (200 - 성공)
-include::{snippets}/tmp-board-detail/board-detail-success/response-fields.adoc[]
-include::{snippets}/tmp-board-detail/board-detail-success/response-body.adoc[]
+include::{snippets}/get-tmp-board-detail/get-tmp-board-detail-success/response-fields.adoc[]
+include::{snippets}/get-tmp-board-detail/get-tmp-board-detail-success/response-body.adoc[]
 
 ==== Response Body (401 - 존재하지 않는 사용자)
-include::{snippets}/tmp-board-detail/board-detail-fail-member-not-found/response-fields.adoc[]
-include::{snippets}/tmp-board-detail/board-detail-fail-member-not-found/response-body.adoc[]
+include::{snippets}/get-tmp-board-detail/get-tmp-board-detail-fail-member-not-found/response-fields.adoc[]
+include::{snippets}/get-board-detail/board-detail-board-not-found/response-body.adoc[]
 

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -3,37 +3,21 @@ package com.carrot.carrotmarketclonecoding.board.controller;
 import static com.carrot.carrotmarketclonecoding.board.displayname.BoardTestDisplayNames.MESSAGE.*;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartBody;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
-import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
-import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
-import com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE;
+import com.carrot.carrotmarketclonecoding.board.helper.board.BoardDtoFactory;
+import com.carrot.carrotmarketclonecoding.board.helper.board.BoardTestHelper;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardServiceImpl;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
@@ -43,37 +27,38 @@ import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessExc
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
 import com.carrot.carrotmarketclonecoding.util.ResultFields;
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.http.MediaType;
+import org.springframework.context.annotation.Import;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.FieldDescriptor;
-import org.springframework.restdocs.payload.RequestPartFieldsSnippet;
-import org.springframework.restdocs.payload.ResponseFieldsSnippet;
-import org.springframework.restdocs.request.PathParametersSnippet;
-import org.springframework.restdocs.request.QueryParametersSnippet;
-import org.springframework.restdocs.request.RequestPartsSnippet;
-import org.springframework.test.web.servlet.ResultActions;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
+@Import(value = {
+        BoardTestHelper.class,
+        BoardDtoFactory.class
+})
 @WithCustomMockUser
 @WebMvcTest(controllers = BoardController.class)
 class BoardControllerTest extends RestDocsTestUtil {
 
+    private BoardTestHelper testHelper;
+
+    @Autowired
+    private BoardDtoFactory dtoFactory;
+
     @MockBean
     private BoardServiceImpl boardService;
+
+    @BeforeEach
+    public void setUp() {
+        this.testHelper = new BoardTestHelper(mvc, restDocs);
+    }
 
     @Nested
     @DisplayName(BOARD_REGISTER_CONTROLLER_TEST)
@@ -82,240 +67,121 @@ class BoardControllerTest extends RestDocsTestUtil {
         private MockMultipartFile[] pictures;
         private MockMultipartFile registerRequest;
 
-        private static final String REGISTER_BOARD_URL = "/board/register";
-        private static final String REGISTER_TMP_BOARD_URL = "/board/register/tmp";
-
         @BeforeEach
         public void setUp() throws Exception {
-            this.pictures = createMockMultipartFiles("pictures", 2);
-            this.registerRequest = createRegisterRequestMultipartFile(BoardRegisterRequestDto.builder()
-                    .title("title")
-                    .categoryId(1L)
-                    .method(Method.SELL)
-                    .price(200000)
-                    .suggest(true)
-                    .description("description")
-                    .place("amsa")
-                    .build());
+            this.pictures = dtoFactory.createMockMultipartFiles("pictures", 2);
+            this.registerRequest = dtoFactory.createRegisterRequestMultipartFile(
+                    dtoFactory.createRegisterRequestDto()
+            );
         }
 
         @Test
         @DisplayName(SUCCESS)
         void boardRegisterSuccess() throws Exception {
             // given
-            // when
-            when(boardService.register(any(), any(), any(), anyBoolean())).thenReturn(1L);
-
-            // then
-            assertRegisterBoardSuccess(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isCreated())
                     .status(201)
                     .result(true)
                     .message(BOARD_REGISTER_SUCCESS.getMessage())
-                    .build());
-        }
+                    .build();
 
-        @Test
-        @DisplayName(SUCCESS_REGISTER_TMP_BOARD)
-        void boardRegisterTmpSuccess() throws Exception {
-            // given
             // when
-            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenReturn(1L);
+            when(boardService.register(any(), any(), any(), anyBoolean())).thenReturn(1L);
 
             // then
-            assertRegisterTmpBoardSuccess(ResultFields.builder()
-                    .resultMatcher(status().isCreated())
-                    .status(201)
-                    .result(true)
-                    .message(BOARD_REGISTER_TEMPORARY_SUCCESS.getMessage())
-                    .build());
+            testHelper.assertRegisterBoardSuccess(resultFields, registerRequest, pictures);
         }
 
         @Test
         @DisplayName(FAIL_FILE_COUNT_OVER_10)
         void boardRegisterFileUploadLimitExceeded() throws Exception {
             // given
-            // when
-            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(FileUploadLimitException.class);
-
-            // then
-            assertRegisterBoardFailed(ResultFields.builder()
+            this.pictures = dtoFactory.createMockMultipartFiles("pictures", 30);
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isInternalServerError())
                     .status(500)
                     .result(false)
                     .message(FILE_UPLOAD_LIMIT.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(FileUploadLimitException.class);
+
+            // then
+            testHelper.assertRegisterBoardFailed(resultFields, registerRequest, pictures);
         }
 
         @Test
         @DisplayName(FAIL_INPUT_NOT_VALID)
         void boardRegisterValidationFailed() throws Exception {
             // given
-            registerRequest = createRegisterRequestMultipartFile(new BoardRegisterRequestDto());
-
-            // when
-            // then
-            assertRegisterBoardFailedInvalidInput(ResultFields.builder()
+            registerRequest = dtoFactory.createRegisterRequestMultipartFile(new BoardRegisterRequestDto());
+            Map<String, String> errorMessages = dtoFactory.createInputInvalidResponseData();
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isBadRequest())
                     .status(400)
                     .result(false)
                     .message(INPUT_NOT_VALID.getMessage())
-                    .build());
-        }
+                    .build();
 
-        private Map<String, String> createInputInvalidResponseData() {
-            Map<String, String> responseData = new HashMap<>();
-            responseData.put("title", MESSAGE.TITLE_NOT_VALID);
-            responseData.put("categoryId", MESSAGE.CATEGORY_NOT_VALID);
-            responseData.put("method", "잘못된 입력입니다!");
-            responseData.put("price", MESSAGE.PRICE_NOT_VALID);
-            responseData.put("suggest", MESSAGE.SUGGEST_NOT_VALID);
-            responseData.put("description", MESSAGE.DESCRIPTION_NOT_VALID);
-            responseData.put("place", MESSAGE.PLACE_NOT_VALID);
-            return responseData;
+            // when
+            // then
+            testHelper.assertRegisterBoardFailedInvalidInput(resultFields, registerRequest, pictures, errorMessages);
         }
 
         @Test
         @DisplayName(FAIL_WRITER_NOT_FOUND)
         void boardRegisterMemberNotFound() throws Exception {
             // given
-            // when
-            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(MemberNotFoundException.class);
-
-            // then
-            assertRegisterBoardFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(MemberNotFoundException.class);
+
+            // then
+            testHelper.assertRegisterBoardFailed(resultFields, registerRequest, pictures);
         }
 
         @Test
         @DisplayName(FAIL_CATEGORY_NOT_FOUND)
         void boardRegisterCategoryNotFound() throws Exception {
             // given
-            // when
-            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(CategoryNotFoundException.class);
-
-            // then
-            assertRegisterBoardFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isBadRequest())
                     .status(400)
                     .result(false)
                     .message(CATEGORY_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenThrow(CategoryNotFoundException.class);
+
+            // then
+            testHelper.assertRegisterBoardFailed(resultFields, registerRequest, pictures);
         }
 
-        /**
-         * TODO REFACTOR 클래스 분리 A
-         * 게시글 작성 성공 테스트
-         */
-        private void assertRegisterBoardSuccess(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestRegisterBoard(REGISTER_BOARD_URL), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(createDocument());
-        }
+        @Test
+        @DisplayName(SUCCESS_REGISTER_TMP_BOARD)
+        void boardRegisterTmpSuccess() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isCreated())
+                    .status(201)
+                    .result(true)
+                    .message(BOARD_REGISTER_TEMPORARY_SUCCESS.getMessage())
+                    .build();
 
-        /**
-         * TODO REFACTOR 클래스 분리 A
-         * 임시 게시글 작성 성공 테스트
-         */
-        private void assertRegisterTmpBoardSuccess(ResultFields resultFields) throws Exception {
-            assertResponseResult(
-                    requestRegisterBoard(REGISTER_TMP_BOARD_URL), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(createDocument());
-        }
+            // when
+            when(boardService.register(anyLong(), any(), any(), anyBoolean())).thenReturn(1L);
 
-        private RestDocumentationResultHandler createDocument() {
-            return restDocs.document(
-                    documentRequestParts(),
-                    requestPartBody("registerRequest"),
-                    documentRequestPartFields(),
-                    responseFields(createResponseResultDescriptor())
-            );
-        }
-
-        private RequestPartsSnippet documentRequestParts() {
-            return requestParts(
-                    partWithName("registerRequest").description("게시글 작성 입력값"),
-                    partWithName("pictures").description("첨부사진")
-            );
-        }
-
-        private RequestPartFieldsSnippet documentRequestPartFields() {
-            return requestPartFields("registerRequest",
-                    fieldWithPath("title").description("게시글 제목"),
-                    fieldWithPath("categoryId").description("카테고리 아이디"),
-                    fieldWithPath("method").description("거래 방식 (SELL/SHARE)"),
-                    fieldWithPath("price").description("상품 가격"),
-                    fieldWithPath("suggest").description("가격 제안 여부"),
-                    fieldWithPath("description").description("상품 설명"),
-                    fieldWithPath("place").description("거래 희망 장소")
-            );
-        }
-
-        /**
-         * TODO REFACTOR class A
-         * 게시글 작성 실패 테스트
-         */
-        private void assertRegisterBoardFailed(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestRegisterBoard(REGISTER_BOARD_URL), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(restDocs.document(
-                            responseFields(createResponseResultDescriptor())
-                    ));
-        }
-
-        /**
-         * TODO REFACTOR class A
-         * 게시글 작성 입력값 유효x
-         */
-        private void assertRegisterBoardFailedInvalidInput(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestRegisterBoard(REGISTER_BOARD_URL), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(createInputInvalidResponseData())))
-                    .andDo(restDocs.document(
-                            responseFields(
-                                    fieldWithPath("status").description("응답 상태"),
-                                    fieldWithPath("result").description("응답 결과"),
-                                    fieldWithPath("message").description("응답 메시지"),
-                                    fieldWithPath("data.title").description("응답 본문 - 제목을 입력하지 않음"),
-                                    fieldWithPath("data.categoryId").description("응답 본문 - 카테고리아이디를 입력하지 않음"),
-                                    fieldWithPath("data.method").description("응답 본문 - 거래방식을 입력하지 않음"),
-                                    fieldWithPath("data.price").description("응답 본문 - 가격을 입력하지 않음"),
-                                    fieldWithPath("data.suggest").description("응답 본문 - 가격 제안 여부를 입력하지 않음"),
-                                    fieldWithPath("data.description").description("응답 본문 - 상품 설명을 입력하지 않음"),
-                                    fieldWithPath("data.place").description("응답 본문 - 거래 장소를 입력하지 않음")
-                            )
-                    ));
-        }
-
-        /**
-         * TODO REFACTOR class A
-         * 게시글 작성 API 요청
-         */
-        private ResultActions requestRegisterBoard(String url) throws Exception {
-            return mvc.perform(
-                    requestWithCsrfAndSetContentType(
-                            requestMultipartFiles(multipart(url), pictures).file(registerRequest),
-                            MediaType.MULTIPART_FORM_DATA
-                    )
-            );
-        }
-
-        /**
-         * // TODO REFACTOR class A
-         * 게시글 작성 RequestPart 생성
-         */
-        private MockMultipartFile createRegisterRequestMultipartFile(BoardRegisterRequestDto registerRequestDto) throws Exception {
-            String registerRequestJson = new ObjectMapper().writeValueAsString(registerRequestDto);
-            return new MockMultipartFile(
-                    "registerRequest",
-                    "registerRequest.json",
-                    "application/json",
-                    registerRequestJson.getBytes()
-            );
+            // then
+            testHelper.assertRegisterTmpBoardSuccess(resultFields, registerRequest, pictures);
         }
     }
 
@@ -323,91 +189,42 @@ class BoardControllerTest extends RestDocsTestUtil {
     @DisplayName(BOARD_DETAIL_CONTROLLER_TEST)
     class GetBoardDetail {
 
-        private static final String URL = "/board/{id}";
-
         @Test
         @DisplayName(SUCCESS)
         void boardDetailSuccess() throws Exception {
             // given
             Long boardId = 1L;
-            BoardDetailResponseDto response = createBoardDetailResponseDto();
+            BoardDetailResponseDto response = dtoFactory.createBoardDetailResponseDto();
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(BOARD_GET_DETAIL_SUCCESS.getMessage())
+                    .build();
 
             // when
             when(boardService.detail(anyLong(), any())).thenReturn(response);
 
             // then
-            assertGetBoardDetailSuccess(ResultFields.builder()
-                    .resultMatcher(status().isOk())
-                    .status(200)
-                    .result(true)
-                    .message(BOARD_GET_DETAIL_SUCCESS.getMessage())
-                    .build(), "$.data.id", boardId.intValue());
+            testHelper.assertGetBoardDetailSuccess(resultFields, "$.data.id", boardId.intValue());
         }
 
         @Test
         @DisplayName(FAIL_BOARD_NOT_FOUND)
         void boardDetailBoardNotFound() throws Exception {
             // given
-            // when
-            when(boardService.detail(anyLong(), any())).thenThrow(new BoardNotFoundException());
-
-            // then
-            assertGetBoardDetailFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isBadRequest())
                     .status(400)
                     .result(false)
                     .message(BOARD_NOT_FOUND.getMessage())
-                    .build());
-        }
+                    .build();
 
-        private void assertGetBoardDetailSuccess(ResultFields resultFields, String dataJsonPath, Object data) throws Exception {
-            assertResponseResult(requestGetBoardDetail(), resultFields)
-                    .andExpect(jsonPath(dataJsonPath, equalTo(data)))
-                    .andDo(restDocs.document(
-                            documentPathParameters(),
-                            responseFields(createBoardDetailSuccessDescriptor())
-                    ));
-        }
+            // when
+            when(boardService.detail(anyLong(), any())).thenThrow(new BoardNotFoundException());
 
-        private void assertGetBoardDetailFailed(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestGetBoardDetail(), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(restDocs.document(
-                            documentPathParameters(),
-                            responseFields(createResponseResultDescriptor())
-                    ));
-        }
-
-        private ResultActions requestGetBoardDetail() throws Exception {
-            return mvc.perform(get(URL, 1L).accept(MediaType.APPLICATION_JSON));
-        }
-
-        private PathParametersSnippet documentPathParameters() {
-            return pathParameters(parameterWithName("id").description("게시글 ID"));
-        }
-
-        private FieldDescriptor[] createBoardDetailSuccessDescriptor() {
-            return new FieldDescriptor[] {
-                    fieldWithPath("status").description("응답 상태"),
-                    fieldWithPath("result").description("응답 결과"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("data.id").description("게시글 아이디"),
-                    fieldWithPath("data.writer").description("작성자"),
-                    fieldWithPath("data.place").description("거래 장소"),
-                    fieldWithPath("data.profileUrl").description("프로필 사진 URL"),
-                    fieldWithPath("data.status").description("거래 상태"),
-                    fieldWithPath("data.title").description("게시글 제목"),
-                    fieldWithPath("data.category").description("카테고리"),
-                    fieldWithPath("data.method").description("거래 방식"),
-                    fieldWithPath("data.price").description("상품 가격"),
-                    fieldWithPath("data.suggest").description("가격 제안 여부"),
-                    fieldWithPath("data.createDate").description("게시글 생성일"),
-                    fieldWithPath("data.description").description("상품 설명"),
-                    fieldWithPath("data.pictures").description("상품 사진"),
-                    fieldWithPath("data.chat").description("채팅 수"),
-                    fieldWithPath("data.like").description("좋아요수"),
-                    fieldWithPath("data.visit").description("조회수")
-            };
+            // then
+            testHelper.assertGetBoardDetailFailed(resultFields);
         }
     }
 
@@ -415,198 +232,85 @@ class BoardControllerTest extends RestDocsTestUtil {
     @DisplayName(BOARD_SEARCH_CONTROLLER_TEST)
     class SearchBoards {
 
-        private static final String URL = "/board";
-
         @Test
         @DisplayName(SUCCESS)
         void searchBoardsSuccess() throws Exception {
             // given
-            List<BoardSearchResponseDto> searchResponseDtos = createBoardSearchResponseDtos(2);
-
-            // when
-            PageResponseDto<BoardSearchResponseDto> response = createBoardSearchResponse(0, 10, 2, searchResponseDtos);
-            when(boardService.search(anyLong(), any(), any())).thenReturn(response);
-
-            // then
-            assertSearchBoardsSuccess(ResultFields.builder()
+            List<BoardSearchResponseDto> searchResponseDtos = dtoFactory.createBoardSearchResponseDtos(2);
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isOk())
                     .status(200)
                     .result(true)
                     .message(SEARCH_BOARDS_SUCCESS.getMessage())
-                    .build(), 2);
+                    .build();
+
+            // when
+            PageResponseDto<BoardSearchResponseDto> response = dtoFactory.createBoardSearchResponse(0, 10, 2, searchResponseDtos);
+            when(boardService.search(anyLong(), any(), any())).thenReturn(response);
+
+            // then
+            testHelper.assertSearchBoardsSuccess(resultFields, 2);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void searchBoardsMemberNotFound() throws Exception {
             // given
-            // when
-            doThrow(MemberNotFoundException.class).when(boardService).search(any(), any(), any());
-
-            // then
-            assertSearchBoardsFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
-        }
+                    .build();
 
-        private void assertSearchBoardsSuccess(ResultFields resultFields, int contentSize) throws Exception {
-            assertResponseResult(requestGetSearchBoards(), resultFields)
-                    .andExpect(jsonPath("$.data.contents.size()", equalTo(contentSize)))
-                    .andDo(restDocs.document(
-                            documentQueryParameters(),
-                            documentResponseFields()
-                    ));
-        }
+            // when
+            doThrow(MemberNotFoundException.class).when(boardService).search(any(), any(), any());
 
-        private void assertSearchBoardsFailed(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestGetSearchBoards(), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(restDocs.document(
-                            documentQueryParameters(),
-                            responseFields(createResponseResultDescriptor())
-                    ));
-        }
+            // then
 
-        private ResultActions requestGetSearchBoards() throws Exception {
-            return mvc.perform(get(URL)
-                    .param("categoryId", "1")
-                    .param("keyword", "title")
-                    .param("minPrice", "0")
-                    .param("maxPrice", "20000")
-                    .param("order", "NEWEST")
-                    .param("page", "0")
-            );
-        }
-
-        private QueryParametersSnippet documentQueryParameters() {
-            return queryParameters(
-                    parameterWithName("categoryId").description("카테고리 아이디"),
-                    parameterWithName("keyword").description("검색 키워드"),
-                    parameterWithName("minPrice").description("최소 가격"),
-                    parameterWithName("maxPrice").description("최대 가격"),
-                    parameterWithName("order").description("정렬 순서"),
-                    parameterWithName("page").description("요청 페이지 번호")
-            );
-        }
-
-        private ResponseFieldsSnippet documentResponseFields() {
-            return responseFields(
-                    fieldWithPath("status").description("응답 상태"),
-                    fieldWithPath("result").description("응답 결과"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("data.contents[].id").description("게시글 아이디"),
-                    fieldWithPath("data.contents[].pictureUrl").description("사진 URL"),
-                    fieldWithPath("data.contents[].title").description("게시글 제목"),
-                    fieldWithPath("data.contents[].place").description("거래 장소"),
-                    fieldWithPath("data.contents[].createDate").description("게시글 생성일"),
-                    fieldWithPath("data.contents[].price").description("상품 가격"),
-                    fieldWithPath("data.contents[].like").description("좋아요 수"),
-                    fieldWithPath("data.totalPage").description("전체 페이지 개수"),
-                    fieldWithPath("data.totalElements").description("전체 데이터 수"),
-                    fieldWithPath("data.first").description("첫페이지 여부"),
-                    fieldWithPath("data.last").description("마지막페이지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 개수")
-            );
+            testHelper.assertSearchBoardsFailed(resultFields);
         }
     }
 
     @Nested
     @DisplayName(BOARD_MY_DETAIL_CONTROLLER_TEST)
-    class SearchBoardByStatus {
-
-        private static final String URL = "/board/my";
+    class SearchMyBoards {
 
         @Test
         @DisplayName(SUCCESS)
-        void searchBoardsByStatusSuccess() throws Exception {
+        void searchMyBoardsSuccess() throws Exception {
             // given
-            PageResponseDto<BoardSearchResponseDto> response = createBoardSearchResponse(0, 10, 30, createBoardSearchResponseDtos(30));
+            PageResponseDto<BoardSearchResponseDto> response = dtoFactory.createBoardSearchResponse(0, 10, 30, dtoFactory.createBoardSearchResponseDtos(30));
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(SEARCH_BOARDS_SUCCESS.getMessage())
+                    .build();
 
             // when
             when(boardService.searchMyBoards(anyLong(), any(), any())).thenReturn(response);
 
             // then
-            assertSearchMyBoardsSuccess(ResultFields.builder()
-                    .resultMatcher(status().isOk())
-                    .status(200)
-                    .result(true)
-                    .message(SEARCH_BOARDS_SUCCESS.getMessage())
-                    .build());
+            testHelper.assertSearchMyBoardsSuccess(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
-        void searchBoardsByStatusFailMemberNotFound() throws Exception {
+        void searchMyBoardsFailMemberNotFound() throws Exception {
             // given
-            // when
-            doThrow(MemberNotFoundException.class).when(boardService).searchMyBoards(anyLong(), any(), any());
-
-            // then
-            assertSearchMyBoardsFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
-        }
+                    .build();
 
-        private void assertSearchMyBoardsSuccess(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestSearchBoardsByStatus(), resultFields)
-                    .andExpect(jsonPath("$.data.contents.size()", equalTo(30)))
-                    .andExpect(jsonPath("$.data.totalPage", equalTo(3)))
-                    .andExpect(jsonPath("$.data.totalElements", equalTo(30)))
-                    .andExpect(jsonPath("$.data.first", equalTo(true)))
-                    .andExpect(jsonPath("$.data.last", equalTo(false)))
-                    .andExpect(jsonPath("$.data.numberOfElements", equalTo(30)))
-                    .andDo(createDocument());
-        }
+            // when
+            doThrow(MemberNotFoundException.class).when(boardService).searchMyBoards(anyLong(), any(), any());
 
-        private RestDocumentationResultHandler createDocument() {
-            return restDocs.document(documentQueryParameters(), documentResponseFields());
-        }
-
-        private QueryParametersSnippet documentQueryParameters() {
-            return queryParameters(
-                    parameterWithName("status").description("거래 상태"),
-                    parameterWithName("hide").description("숨김 여부")
-            );
-        }
-
-        private ResponseFieldsSnippet documentResponseFields() {
-            return responseFields(
-                    fieldWithPath("status").description("응답 상태"),
-                    fieldWithPath("result").description("응답 결과"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("data.contents[].id").description("게시글 아이디"),
-                    fieldWithPath("data.contents[].pictureUrl").description("사진 URL"),
-                    fieldWithPath("data.contents[].title").description("게시글 제목"),
-                    fieldWithPath("data.contents[].place").description("거래 장소"),
-                    fieldWithPath("data.contents[].createDate").description("게시글 생성일"),
-                    fieldWithPath("data.contents[].price").description("상품 가격"),
-                    fieldWithPath("data.contents[].like").description("좋아요 수"),
-                    fieldWithPath("data.totalPage").description("전체 페이지 개수"),
-                    fieldWithPath("data.totalElements").description("전체 데이터 수"),
-                    fieldWithPath("data.first").description("첫페이지 여부"),
-                    fieldWithPath("data.last").description("마지막페이지 여부"),
-                    fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 개수")
-            );
-        }
-
-        private void assertSearchMyBoardsFailed(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestSearchBoardsByStatus(), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(restDocs.document(
-                            responseFields(createResponseResultDescriptor())
-                    ));
-        }
-
-        private ResultActions requestSearchBoardsByStatus() throws Exception {
-            return mvc.perform(get(URL)
-                    .param("status", "SELL")
-                    .param("hide", "true"));
+            // then
+            testHelper.assertSearchMyBoardsFailed(resultFields);
         }
     }
 
@@ -617,146 +321,82 @@ class BoardControllerTest extends RestDocsTestUtil {
         MockMultipartFile updateRequest;
         MockMultipartFile[] newPictures;
 
-        private static final String URL = "/board/{id}";
-
         @BeforeEach
         public void setUp() throws Exception {
-            this.updateRequest = createUpdateRequest();
-            this.newPictures = createMockMultipartFiles("newPictures", 3);
+            this.updateRequest = dtoFactory.createUpdateRequest();
+            this.newPictures = dtoFactory.createMockMultipartFiles("newPictures", 3);
         }
 
         @Test
         @DisplayName(SUCCESS)
         void boardUpdateSuccess() throws Exception {
             // given
-            // when
-            doNothing().when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
-
-            // then
-            assertUpdateBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isOk())
                     .status(200)
                     .result(true)
                     .message(BOARD_UPDATE_SUCCESS.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            doNothing().when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
+
+            // then
+            testHelper.assertUpdateBoard(resultFields, newPictures, updateRequest);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void boardUpdateFailMemberNotFound() throws Exception {
             // given
-            // when
-            doThrow(MemberNotFoundException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
-
-            // then
-            assertUpdateBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            doThrow(MemberNotFoundException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
+
+            // then
+            testHelper.assertUpdateBoard(resultFields, newPictures, updateRequest);
         }
 
         @Test
         @DisplayName(FAIL_BOARD_NOT_FOUND)
         void boardUpdateFailBoardNotFound() throws Exception {
             // given
-            // when
-            doThrow(BoardNotFoundException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
-
-            // then
-            assertUpdateBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isBadRequest())
                     .status(400)
                     .result(false)
                     .message(BOARD_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            doThrow(BoardNotFoundException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
+
+            // then
+            testHelper.assertUpdateBoard(resultFields, newPictures, updateRequest);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_IS_NOT_WRITER)
         void boardUpdateFailMemberIsNotWriter() throws Exception {
             // given
-            // when
-            doThrow(UnauthorizedAccessException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
-
-            // then
-            assertUpdateBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isForbidden())
                     .status(403)
                     .result(false)
                     .message(UNAUTHORIZED_ACCESS.getMessage())
-                    .build());
-        }
-
-        // TODO BoardResponseValidator
-        private void assertUpdateBoard(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestUpdateBoard(), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(createDocument());
-        }
-
-        private ResultActions requestUpdateBoard() throws Exception {
-            return mvc.perform(
-                    requestWithCsrfAndSetContentType(
-                            requestMultipartFiles(multipart(URL, 1L), newPictures)
-                                    .file(updateRequest)
-                                    .with(request -> {
-                                        request.setMethod("PATCH");
-                                        return request;
-                                    }),
-                            MediaType.MULTIPART_FORM_DATA
-                    )
-            );
-        }
-
-        // TODO BoardDocumentCreator
-        private RestDocumentationResultHandler createDocument() {
-            return restDocs.document(
-                    pathParameters(
-                            parameterWithName("id").description("수정할 게시글 ID")
-                    ),
-                    requestParts(
-                            partWithName("updateRequest").description("게시글 수정 입력값"),
-                            partWithName("newPictures").description("새 첨부사진")
-                    ),
-                    requestPartBody("updateRequest"),
-                    requestPartFields("updateRequest",
-                            fieldWithPath("title").description("게시글 제목"),
-                            fieldWithPath("categoryId").description("카테고리 아이디"),
-                            fieldWithPath("method").description("거래 방식 (SELL/SHARE)"),
-                            fieldWithPath("price").description("상품 가격"),
-                            fieldWithPath("suggest").description("가격 제안 여부"),
-                            fieldWithPath("description").description("상품 설명"),
-                            fieldWithPath("place").description("거래 희망 장소"),
-                            fieldWithPath("removePictures").description("삭제할 이미지 아이디")
-                    ),
-                    responseFields(createResponseResultDescriptor())
-            );
-        }
-
-        // TODO BoardTestDataFactory
-        private MockMultipartFile createUpdateRequest() throws Exception {
-            String updateRequestJson = new ObjectMapper().writeValueAsString(createUpdateRequestDto());
-            return new MockMultipartFile(
-                    "updateRequest",
-                    "updateRequest.json",
-                    "application/json",
-                    updateRequestJson.getBytes()
-            );
-        }
-
-        private BoardUpdateRequestDto createUpdateRequestDto() {
-            return BoardUpdateRequestDto.builder()
-                    .title("Sell My MacBook")
-                    .categoryId(2L)
-                    .method(Method.SELL)
-                    .price(1000000)
-                    .suggest(false)
-                    .description("It's my MacBook description")
-                    .place("Amsa")
-                    .removePictures(new Long[]{1L, 2L, 3L})
                     .build();
+
+            // when
+            doThrow(UnauthorizedAccessException.class).when(boardService).update(anyLong(), anyLong(), any(BoardUpdateRequestDto.class), any());
+
+            // then
+            testHelper.assertUpdateBoard(resultFields, newPictures, updateRequest);
         }
     }
 
@@ -764,235 +404,137 @@ class BoardControllerTest extends RestDocsTestUtil {
     @DisplayName(BOARD_DELETE_CONTROLLER_TEST)
     class DeleteBoard {
 
-        private static final String URL = "/board/{id}";
-
         @Test
         @DisplayName(SUCCESS)
         void deleteBoardSuccess() throws Exception {
             // given
-            // when
-            doNothing().when(boardService).delete(anyLong(), anyLong());
-
-            // then
-            assertDeleteBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isOk())
                     .status(200)
                     .result(true)
                     .message(BOARD_DELETE_SUCCESS.getMessage())
-                    .build());
+                    .build();
+            
+            // when
+            doNothing().when(boardService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteBoard(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_BOARD_NOT_FOUND)
         void deleteBoardFailBoardNotFound() throws Exception {
             // given
-            // when
-            doThrow(BoardNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
-
-            // then
-            assertDeleteBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isBadRequest())
                     .status(400)
                     .result(false)
                     .message(BOARD_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+            
+            // when
+            doThrow(BoardNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteBoard(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void deleteBoardFailMemberNotFound() throws Exception {
             // given
-            // when
-            doThrow(MemberNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
-
-            // then
-            assertDeleteBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+            
+            // when
+            doThrow(MemberNotFoundException.class).when(boardService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteBoard(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_IS_NOT_WRITER)
         void deleteBoardFailMemberIsNotWriter() throws Exception {
             // given
-            // when
-            doThrow(UnauthorizedAccessException.class).when(boardService).delete(anyLong(), anyLong());
-
-            // then
-            assertDeleteBoard(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isForbidden())
                     .status(403)
                     .result(false)
                     .message(UNAUTHORIZED_ACCESS.getMessage())
-                    .build());
-        }
+                    .build();
 
-        private void assertDeleteBoard(ResultFields resultFields) throws Exception {
-            assertResponseResult(requestDeleteBoard(), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(createDocument());
-        }
+            // when
+            doThrow(UnauthorizedAccessException.class).when(boardService).delete(anyLong(), anyLong());
 
-        private ResultActions requestDeleteBoard() throws Exception {
-            return mvc.perform(requestWithCsrf(delete(URL, 1L)));
-        }
+            // then
 
-        private RestDocumentationResultHandler createDocument() {
-            return restDocs.document(
-                    pathParameters(
-                            parameterWithName("id").description("삭제할 게시글 ID")
-                    ),
-                    responseFields(createResponseResultDescriptor())
-            );
+            testHelper.assertDeleteBoard(resultFields);
         }
     }
 
     @Nested
     @DisplayName(BOARD_GET_TMP_CONTROLLER_TEST)
-    class TmpBoardDetail {
-
-        private static final String URL = "/board/tmp";
+    class GetTmpBoardDetail {
 
         @Test
         @DisplayName(SUCCESS)
-        void boardDetailSuccess() throws Exception {
+        void getTmpBoardDetailSuccess() throws Exception {
             // given
-            BoardDetailResponseDto response = createBoardDetailResponseDto();
-
-            // when
-            when(boardService.tmpBoardDetail(anyLong())).thenReturn(response);
-
-            // then
+            BoardDetailResponseDto response = dtoFactory.createBoardDetailResponseDto();
             ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isOk())
                     .status(200)
                     .result(true)
                     .message(BOARD_GET_TMP_SUCCESS.getMessage())
                     .build();
-            assertGetTmpBoardDetailSuccess(resultFields, "$.data.id", response.getId().intValue());
+
+            // when
+            when(boardService.tmpBoardDetail(anyLong())).thenReturn(response);
+
+            // then
+            testHelper.assertGetTmpBoardDetailSuccess(resultFields, "$.data.id", response.getId().intValue());
         }
 
         @Test
         @DisplayName(SUCCESS_NO_TMP_BOARDS)
-        void boardDetailSuccessNotTmpBoard() throws Exception {
+        void getTmpBoardDetailSuccessNotTmpBoard() throws Exception {
             // given
-            // when
-            when(boardService.tmpBoardDetail(anyLong())).thenReturn(null);
-
-            // then
-            assertTmpBoardDetailFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isOk())
                     .status(200)
                     .result(true)
                     .message(BOARD_GET_TMP_SUCCESS.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            when(boardService.tmpBoardDetail(anyLong())).thenReturn(null);
+
+            // then
+            testHelper.assertTmpBoardDetailFailed(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
-        void boardDetailFailMemberNotFound() throws Exception {
+        void getTmpBoardDetailFailMemberNotFound() throws Exception {
             // given
-            // when
-            doThrow(MemberNotFoundException.class).when(boardService).tmpBoardDetail(anyLong());
-
-            // then
-            assertTmpBoardDetailFailed(ResultFields.builder()
+            ResultFields resultFields = ResultFields.builder()
                     .resultMatcher(status().isUnauthorized())
                     .status(401)
                     .result(false)
                     .message(MEMBER_NOT_FOUND.getMessage())
-                    .build());
+                    .build();
+
+            // when
+            doThrow(MemberNotFoundException.class).when(boardService).tmpBoardDetail(anyLong());
+
+            // then
+            testHelper.assertTmpBoardDetailFailed(resultFields);
         }
-
-        private void assertGetTmpBoardDetailSuccess(ResultFields resultFields, String jsonPath, Object data) throws Exception {
-            assertResponseResult(mvc.perform(get(URL)), resultFields)
-                    .andExpect(jsonPath(jsonPath, equalTo(data)))
-                    .andDo(restDocs.document(responseFields(createBoardDetailSuccessDescriptor())));
-        }
-
-        private void assertTmpBoardDetailFailed(ResultFields resultFields) throws Exception {
-            assertResponseResult(mvc.perform(get(URL)), resultFields)
-                    .andExpect(jsonPath("$.data", equalTo(null)))
-                    .andDo(restDocs.document(responseFields(createResponseResultDescriptor())));
-        }
-
-        private FieldDescriptor[] createBoardDetailSuccessDescriptor() {
-            return new FieldDescriptor[] {
-                    fieldWithPath("status").description("응답 상태"),
-                    fieldWithPath("result").description("응답 결과"),
-                    fieldWithPath("message").description("응답 메시지"),
-                    fieldWithPath("data.id").description("게시글 아이디"),
-                    fieldWithPath("data.writer").description("작성자"),
-                    fieldWithPath("data.place").description("거래 장소"),
-                    fieldWithPath("data.profileUrl").description("프로필 사진 URL"),
-                    fieldWithPath("data.status").description("거래 상태"),
-                    fieldWithPath("data.title").description("게시글 제목"),
-                    fieldWithPath("data.category").description("카테고리"),
-                    fieldWithPath("data.method").description("거래 방식"),
-                    fieldWithPath("data.price").description("상품 가격"),
-                    fieldWithPath("data.suggest").description("가격 제안 여부"),
-                    fieldWithPath("data.createDate").description("게시글 생성일"),
-                    fieldWithPath("data.description").description("상품 설명"),
-                    fieldWithPath("data.pictures").description("상품 사진"),
-                    fieldWithPath("data.chat").description("채팅 수"),
-                    fieldWithPath("data.like").description("좋아요수"),
-                    fieldWithPath("data.visit").description("조회수")
-            };
-        }
-    }
-
-    private BoardDetailResponseDto createBoardDetailResponseDto() {
-        return BoardDetailResponseDto.builder()
-                .id(1L)
-                .writer("User1")
-                .place("Kangnam")
-                .profileUrl("http://S3-ProfileUrl")
-                .status(Status.SELL)
-                .title("Sell My Keyboards")
-                .category("가전기기")
-                .method(Method.SELL)
-                .price(100000)
-                .suggest(false)
-                .createDate(LocalDateTime.now())
-                .description("This is my keyboard description")
-                .pictures(new ArrayList<>())
-                .chat(2)
-                .like(10)
-                .visit(100)
-                .build();
-    }
-
-    private List<BoardSearchResponseDto> createBoardSearchResponseDtos(int size) {
-        List<BoardSearchResponseDto> searchResponseDtos = new ArrayList<>();
-        for (int i = 0; i < size; i++) {
-            searchResponseDtos.add(BoardSearchResponseDto.builder()
-                    .id((long) i + 1)
-                    .title("Sell My MacBook" + (i + 1))
-                    .price(2000000)
-                    .place("Amsa")
-                    .createDate(LocalDateTime.now())
-                    .pictureUrl("S3 Picture Url")
-                    .build());
-        }
-        return searchResponseDtos;
-    }
-
-    private PageResponseDto<BoardSearchResponseDto> createBoardSearchResponse(int page, int size, int total, List<BoardSearchResponseDto> searchResponseDtos) {
-        return new PageResponseDto<>(new PageImpl<>(searchResponseDtos, PageRequest.of(page, size), total));
-    }
-
-    private MockMultipartFile[] createMockMultipartFiles(String paramName, int size) {
-        MockMultipartFile[] pictures = new MockMultipartFile[size];
-        for (int i = 0; i < size; i++) {
-            pictures[i] = new MockMultipartFile(
-                    paramName,
-                    "picture " + i + ".png",
-                    "image/png",
-                    ("picture " + i).getBytes());
-        };
-        return pictures;
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardLikeControllerTest.java
@@ -13,19 +13,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.helper.boardlike.BoardLikeDtoFactory;
-import com.carrot.carrotmarketclonecoding.board.helper.boardlike.BoardLikeRequestHelper;
-import com.carrot.carrotmarketclonecoding.board.helper.boardlike.BoardLikeRestDocsHelper;
 import com.carrot.carrotmarketclonecoding.board.helper.boardlike.BoardLikeTestHelper;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardLikeServiceImpl;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberAlreadyLikedBoardException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
-import com.carrot.carrotmarketclonecoding.util.RestDocsConfig;
-import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
 import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
 import com.carrot.carrotmarketclonecoding.util.ResultFields;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -36,22 +33,23 @@ import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
-@Import(value = {RestDocsHelper.class,
-        RestDocsTestUtil.class,
-        RestDocsConfig.class,
-        BoardLikeRequestHelper.class,
+@Import(value = {
         BoardLikeTestHelper.class,
-        BoardLikeRestDocsHelper.class,
-        BoardLikeDtoFactory.class})
+        BoardLikeDtoFactory.class
+})
 @WithCustomMockUser
 @WebMvcTest(controllers = BoardLikeController.class)
 class BoardLikeControllerTest extends RestDocsTestUtil {
 
-    @Autowired
     private BoardLikeTestHelper testHelper;
 
     @MockBean
     private BoardLikeServiceImpl boardLikeService;
+
+    @BeforeEach
+    public void setUp() {
+        this.testHelper = new BoardLikeTestHelper(mvc, restDocs);
+    }
 
     @Nested
     @DisplayName(ADD_BOARD_LIKE_CONTROLLER_TEST)
@@ -73,7 +71,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
 
             // then
 
-            testHelper.assertLikeBoard(mvc, resultFields, restDocs);
+            testHelper.assertLikeBoard(resultFields);
         }
 
         @Test
@@ -91,7 +89,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
             doThrow(BoardNotFoundException.class).when(boardLikeService).add(anyLong(), anyLong());
 
             // then
-            testHelper.assertLikeBoard(mvc, resultFields, restDocs);
+            testHelper.assertLikeBoard(resultFields);
         }
 
         @Test
@@ -109,7 +107,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
             doThrow(MemberNotFoundException.class).when(boardLikeService).add(anyLong(), anyLong());
 
             // then
-            testHelper.assertLikeBoard(mvc, resultFields, restDocs);
+            testHelper.assertLikeBoard(resultFields);
         }
 
         @Test
@@ -127,7 +125,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
             doThrow(MemberAlreadyLikedBoardException.class).when(boardLikeService).add(anyLong(), anyLong());
 
             // then
-            testHelper.assertLikeBoard(mvc, resultFields, restDocs);
+            testHelper.assertLikeBoard(resultFields);
         }
     }
 
@@ -158,7 +156,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
             when(boardLikeService.getMemberLikedBoards(anyLong(), any())).thenReturn(result);
 
             // then
-            testHelper.assertGetUserLikedBoardsSuccess(mvc, resultFields, restDocs);
+            testHelper.assertGetUserLikedBoardsSuccess(resultFields);
         }
 
         @Test
@@ -176,7 +174,7 @@ class BoardLikeControllerTest extends RestDocsTestUtil {
             doThrow(MemberNotFoundException.class).when(boardLikeService).getMemberLikedBoards(anyLong(), any());
 
             // then
-            testHelper.assertGetUserLikedBoardsFailed(mvc, resultFields, restDocs);
+            testHelper.assertGetUserLikedBoardsFailed(resultFields);
         }
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardDtoFactory.java
@@ -1,0 +1,133 @@
+package com.carrot.carrotmarketclonecoding.board.helper.board;
+
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
+import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
+import com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE;
+import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@TestComponent
+public class BoardDtoFactory {
+
+    public BoardRegisterRequestDto createRegisterRequestDto() {
+        return BoardRegisterRequestDto.builder()
+                .title("title")
+                .categoryId(1L)
+                .method(Method.SELL)
+                .price(200000)
+                .suggest(true)
+                .description("description")
+                .place("amsa")
+                .build();
+    }
+
+    public MockMultipartFile createRegisterRequestMultipartFile(BoardRegisterRequestDto registerRequestDto) throws Exception {
+        String registerRequestJson = new ObjectMapper().writeValueAsString(registerRequestDto);
+        return new MockMultipartFile(
+                "registerRequest",
+                "registerRequest.json",
+                "application/json",
+                registerRequestJson.getBytes()
+        );
+    }
+
+    public Map<String, String> createInputInvalidResponseData() {
+            Map<String, String> responseData = new HashMap<>();
+            responseData.put("title", MESSAGE.TITLE_NOT_VALID);
+            responseData.put("categoryId", MESSAGE.CATEGORY_NOT_VALID);
+            responseData.put("method", "잘못된 입력입니다!");
+            responseData.put("price", MESSAGE.PRICE_NOT_VALID);
+            responseData.put("suggest", MESSAGE.SUGGEST_NOT_VALID);
+            responseData.put("description", MESSAGE.DESCRIPTION_NOT_VALID);
+            responseData.put("place", MESSAGE.PLACE_NOT_VALID);
+            return responseData;
+    }
+
+    public MockMultipartFile createUpdateRequest() throws Exception {
+        String updateRequestJson = new ObjectMapper().writeValueAsString(createUpdateRequestDto());
+        return new MockMultipartFile(
+                "updateRequest",
+                "updateRequest.json",
+                "application/json",
+                updateRequestJson.getBytes()
+        );
+    }
+
+    public BoardUpdateRequestDto createUpdateRequestDto() {
+        return BoardUpdateRequestDto.builder()
+                .title("Sell My MacBook")
+                .categoryId(2L)
+                .method(Method.SELL)
+                .price(1000000)
+                .suggest(false)
+                .description("It's my MacBook description")
+                .place("Amsa")
+                .removePictures(new Long[]{1L, 2L, 3L})
+                .build();
+    }
+
+    public MockMultipartFile[] createMockMultipartFiles(String paramName, int size) {
+        MockMultipartFile[] pictures = new MockMultipartFile[size];
+        for (int i = 0; i < size; i++) {
+            pictures[i] = new MockMultipartFile(
+                    paramName,
+                    "picture " + i + ".png",
+                    "image/png",
+                    ("picture " + i).getBytes());
+        };
+        return pictures;
+    }
+
+    public BoardDetailResponseDto createBoardDetailResponseDto() {
+        return BoardDetailResponseDto.builder()
+                .id(1L)
+                .writer("User1")
+                .place("Kangnam")
+                .profileUrl("http://S3-ProfileUrl")
+                .status(Status.SELL)
+                .title("Sell My Keyboards")
+                .category("가전기기")
+                .method(Method.SELL)
+                .price(100000)
+                .suggest(false)
+                .createDate(LocalDateTime.now())
+                .description("This is my keyboard description")
+                .pictures(new ArrayList<>())
+                .chat(2)
+                .like(10)
+                .visit(100)
+                .build();
+    }
+
+    public List<BoardSearchResponseDto> createBoardSearchResponseDtos(int size) {
+        List<BoardSearchResponseDto> searchResponseDtos = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            searchResponseDtos.add(BoardSearchResponseDto.builder()
+                    .id((long) i + 1)
+                    .title("Sell My MacBook" + (i + 1))
+                    .price(2000000)
+                    .place("Amsa")
+                    .createDate(LocalDateTime.now())
+                    .pictureUrl("S3 Picture Url")
+                    .build());
+        }
+        return searchResponseDtos;
+    }
+
+    public PageResponseDto<BoardSearchResponseDto> createBoardSearchResponse(int page, int size, int total, List<BoardSearchResponseDto> searchResponseDtos) {
+        return new PageResponseDto<>(new PageImpl<>(searchResponseDtos, PageRequest.of(page, size), total));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRequestHelper.java
@@ -1,0 +1,91 @@
+package com.carrot.carrotmarketclonecoding.board.helper.board;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerRequestUtil;
+import lombok.AllArgsConstructor;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@TestComponent
+@AllArgsConstructor
+public class BoardRequestHelper extends ControllerRequestUtil {
+
+    private final MockMvc mvc;
+
+    private static final String REGISTER_BOARD_URL = "/board/register";
+    private static final String REGISTER_TMP_BOARD_URL = "/board/register/tmp";
+    private static final String GET_BOARD_DETAIL_URL = "/board/{id}";
+    private static final String SEARCH_BOARDS_URL = "/board";
+    private static final String SEARCH_MY_BOARDS_URL = "/board/my";
+    private static final String UPDATE_BOARD_URL = "/board/{id}";
+    private static final String DELETE_BOARD_URL = "/board/{id}";
+    private static final String GET_TMP_BOARD_URL = "/board/tmp";
+
+    public ResultActions requestRegisterBoard(MockMultipartFile request,
+                                              MockMultipartFile[] pictures) throws Exception {
+        return request(REGISTER_BOARD_URL, request, pictures);
+    }
+
+    public ResultActions requestRegisterTmpBoard(MockMultipartFile request,
+                                                 MockMultipartFile[] pictures) throws Exception {
+        return request(REGISTER_TMP_BOARD_URL, request, pictures);
+    }
+
+    private ResultActions request(String url,
+                                  MockMultipartFile request,
+                                  MockMultipartFile[] pictures) throws Exception {
+        return mvc.perform(
+                requestWithCsrfAndSetContentType(
+                        requestWithMultipartFiles(multipart(url), pictures).file(request),
+                        MediaType.MULTIPART_FORM_DATA
+                ));
+    }
+
+    public ResultActions requestGetBoardDetail() throws Exception {
+        return mvc.perform(get(GET_BOARD_DETAIL_URL, 1L).accept(MediaType.APPLICATION_JSON));
+    }
+
+    public ResultActions requestGetSearchBoards() throws Exception {
+        return mvc.perform(get(SEARCH_BOARDS_URL)
+                .param("categoryId", "1")
+                .param("keyword", "title")
+                .param("minPrice", "0")
+                .param("maxPrice", "20000")
+                .param("order", "NEWEST")
+                .param("page", "0")
+        );
+    }
+
+    public ResultActions requestSearchMyBoards() throws Exception {
+        return mvc.perform(get(SEARCH_MY_BOARDS_URL)
+                .param("status", "SELL")
+                .param("hide", "true"));
+    }
+
+    public ResultActions requestUpdateBoard(MockMultipartFile[] newPictures, MockMultipartFile updateRequest) throws Exception {
+        return mvc.perform(
+                requestWithCsrfAndSetContentType(
+                        requestWithMultipartFiles(multipart(UPDATE_BOARD_URL, 1L), newPictures)
+                                .file(updateRequest)
+                                .with(request -> {
+                                    request.setMethod("PATCH");
+                                    return request;
+                                }),
+                        MediaType.MULTIPART_FORM_DATA
+                ));
+    }
+
+    public ResultActions requestDeleteBoard() throws Exception {
+        return mvc.perform(requestWithCsrf(delete(DELETE_BOARD_URL, 1L)));
+    }
+
+    public ResultActions requestGetTmpBoard() throws Exception {
+        return mvc.perform(get(GET_TMP_BOARD_URL));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRestDocsHelper.java
@@ -1,0 +1,252 @@
+package com.carrot.carrotmarketclonecoding.board.helper.board;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartBody;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.payload.RequestPartFieldsSnippet;
+import org.springframework.restdocs.payload.ResponseFieldsSnippet;
+import org.springframework.restdocs.request.PathParametersSnippet;
+import org.springframework.restdocs.request.QueryParametersSnippet;
+import org.springframework.restdocs.request.RequestPartsSnippet;
+import org.springframework.test.web.servlet.ResultHandler;
+
+@TestComponent
+public class BoardRestDocsHelper extends RestDocsHelper {
+
+    private final RestDocumentationResultHandler restDocs;
+
+    public BoardRestDocsHelper(RestDocumentationResultHandler restDocs) {
+        this.restDocs = restDocs;
+    }
+
+    public RestDocumentationResultHandler createRegisterBoardSuccessDocument() {
+        return restDocs.document(
+                documentRequestParts(),
+                requestPartBody("registerRequest"),
+                documentRequestPartFields(),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    private RequestPartsSnippet documentRequestParts() {
+        return requestParts(
+                partWithName("registerRequest").description("게시글 작성 입력값"),
+                partWithName("pictures").description("첨부사진")
+        );
+    }
+
+    private RequestPartFieldsSnippet documentRequestPartFields() {
+        return requestPartFields("registerRequest",
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("categoryId").description("카테고리 아이디"),
+                fieldWithPath("method").description("거래 방식 (SELL/SHARE)"),
+                fieldWithPath("price").description("상품 가격"),
+                fieldWithPath("suggest").description("가격 제안 여부"),
+                fieldWithPath("description").description("상품 설명"),
+                fieldWithPath("place").description("거래 희망 장소")
+        );
+    }
+
+    public RestDocumentationResultHandler createCommonResponseDocument() {
+        return restDocs.document(responseFields(createResponseResultDescriptor()));
+    }
+
+    public RestDocumentationResultHandler createRegisterBoardFailedInvalidInputDocument() {
+        return restDocs.document(
+                responseFields(
+                        fieldWithPath("status").description("응답 상태"),
+                        fieldWithPath("result").description("응답 결과"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data.title").description("응답 본문 - 제목을 입력하지 않음"),
+                        fieldWithPath("data.categoryId").description("응답 본문 - 카테고리아이디를 입력하지 않음"),
+                        fieldWithPath("data.method").description("응답 본문 - 거래방식을 입력하지 않음"),
+                        fieldWithPath("data.price").description("응답 본문 - 가격을 입력하지 않음"),
+                        fieldWithPath("data.suggest").description("응답 본문 - 가격 제안 여부를 입력하지 않음"),
+                        fieldWithPath("data.description").description("응답 본문 - 상품 설명을 입력하지 않음"),
+                        fieldWithPath("data.place").description("응답 본문 - 거래 장소를 입력하지 않음")
+                )
+        );
+    }
+
+    public RestDocumentationResultHandler createGetBoardDetailSuccessDocument() {
+        return createGetBoardDetailDocument(documentGetBoardDetailSuccessResponseFields(createBoardDetailSuccessDescriptor()));
+    }
+
+    public RestDocumentationResultHandler createGetBoardDetailFailedDocument() {
+        return createGetBoardDetailDocument(documentGetBoardDetailSuccessResponseFields(createResponseResultDescriptor()));
+    }
+
+    private RestDocumentationResultHandler createGetBoardDetailDocument(ResponseFieldsSnippet responseFieldsSnippet) {
+        return restDocs.document(documentPathParameters(), responseFieldsSnippet);
+    }
+
+    private PathParametersSnippet documentPathParameters() {
+        return pathParameters(parameterWithName("id").description("게시글 ID"));
+    }
+
+    private ResponseFieldsSnippet documentGetBoardDetailSuccessResponseFields(FieldDescriptor[] descriptors) {
+        return responseFields(descriptors);
+    }
+
+    private FieldDescriptor[] createBoardDetailSuccessDescriptor() {
+        return new FieldDescriptor[] {
+                fieldWithPath("status").description("응답 상태"),
+                fieldWithPath("result").description("응답 결과"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data.id").description("게시글 아이디"),
+                fieldWithPath("data.writer").description("작성자"),
+                fieldWithPath("data.place").description("거래 장소"),
+                fieldWithPath("data.profileUrl").description("프로필 사진 URL"),
+                fieldWithPath("data.status").description("거래 상태"),
+                fieldWithPath("data.title").description("게시글 제목"),
+                fieldWithPath("data.category").description("카테고리"),
+                fieldWithPath("data.method").description("거래 방식"),
+                fieldWithPath("data.price").description("상품 가격"),
+                fieldWithPath("data.suggest").description("가격 제안 여부"),
+                fieldWithPath("data.createDate").description("게시글 생성일"),
+                fieldWithPath("data.description").description("상품 설명"),
+                fieldWithPath("data.pictures").description("상품 사진"),
+                fieldWithPath("data.chat").description("채팅 수"),
+                fieldWithPath("data.like").description("좋아요수"),
+                fieldWithPath("data.visit").description("조회수")
+        };
+    }
+
+    public ResultHandler createSearchBoardsSuccessDocument() {
+        return createSearchBoardsDocument(documentSearchBoardsSuccessResponseFields());
+    }
+
+    public ResultHandler createSearchBoardsFailedDocument() {
+        return createSearchBoardsDocument(responseFields(createResponseResultDescriptor()));
+    }
+
+    private ResultHandler createSearchBoardsDocument(ResponseFieldsSnippet responseFieldsSnippet) {
+        return restDocs.document(documentSearchBoardsQueryParameters(), responseFieldsSnippet);
+    }
+
+    private QueryParametersSnippet documentSearchBoardsQueryParameters() {
+        return queryParameters(
+                parameterWithName("categoryId").description("카테고리 아이디"),
+                parameterWithName("keyword").description("검색 키워드"),
+                parameterWithName("minPrice").description("최소 가격"),
+                parameterWithName("maxPrice").description("최대 가격"),
+                parameterWithName("order").description("정렬 순서"),
+                parameterWithName("page").description("요청 페이지 번호")
+        );
+    }
+
+    private ResponseFieldsSnippet documentSearchBoardsSuccessResponseFields() {
+        return responseFields(
+                fieldWithPath("status").description("응답 상태"),
+                fieldWithPath("result").description("응답 결과"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data.contents[].id").description("게시글 아이디"),
+                fieldWithPath("data.contents[].pictureUrl").description("사진 URL"),
+                fieldWithPath("data.contents[].title").description("게시글 제목"),
+                fieldWithPath("data.contents[].place").description("거래 장소"),
+                fieldWithPath("data.contents[].createDate").description("게시글 생성일"),
+                fieldWithPath("data.contents[].price").description("상품 가격"),
+                fieldWithPath("data.contents[].like").description("좋아요 수"),
+                fieldWithPath("data.totalPage").description("전체 페이지 개수"),
+                fieldWithPath("data.totalElements").description("전체 데이터 수"),
+                fieldWithPath("data.first").description("첫페이지 여부"),
+                fieldWithPath("data.last").description("마지막페이지 여부"),
+                fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 개수")
+        );
+    }
+
+    public RestDocumentationResultHandler createSearchMyBoardsSuccessDocument() {
+        return restDocs.document(documentSearchMyBoardsQueryParameters(), documentSearchMyBoardsResponseFields());
+    }
+
+    private QueryParametersSnippet documentSearchMyBoardsQueryParameters() {
+        return queryParameters(
+                parameterWithName("status").description("거래 상태"),
+                parameterWithName("hide").description("숨김 여부")
+        );
+    }
+
+    private ResponseFieldsSnippet documentSearchMyBoardsResponseFields() {
+        return responseFields(
+                fieldWithPath("status").description("응답 상태"),
+                fieldWithPath("result").description("응답 결과"),
+                fieldWithPath("message").description("응답 메시지"),
+                fieldWithPath("data.contents[].id").description("게시글 아이디"),
+                fieldWithPath("data.contents[].pictureUrl").description("사진 URL"),
+                fieldWithPath("data.contents[].title").description("게시글 제목"),
+                fieldWithPath("data.contents[].place").description("거래 장소"),
+                fieldWithPath("data.contents[].createDate").description("게시글 생성일"),
+                fieldWithPath("data.contents[].price").description("상품 가격"),
+                fieldWithPath("data.contents[].like").description("좋아요 수"),
+                fieldWithPath("data.totalPage").description("전체 페이지 개수"),
+                fieldWithPath("data.totalElements").description("전체 데이터 수"),
+                fieldWithPath("data.first").description("첫페이지 여부"),
+                fieldWithPath("data.last").description("마지막페이지 여부"),
+                fieldWithPath("data.numberOfElements").description("현재 페이지 데이터 개수")
+        );
+    }
+
+    public RestDocumentationResultHandler createUpdateBoardDocument() {
+        return restDocs.document(
+                documentUpdateBoardPathParameters(),
+                documentUpdateBoardRequestParts(),
+                requestPartBody("updateRequest"),
+                documentUpdateBoardRequestPartFields(),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    private RequestPartFieldsSnippet documentUpdateBoardRequestPartFields() {
+        return requestPartFields("updateRequest",
+                fieldWithPath("title").description("게시글 제목"),
+                fieldWithPath("categoryId").description("카테고리 아이디"),
+                fieldWithPath("method").description("거래 방식 (SELL/SHARE)"),
+                fieldWithPath("price").description("상품 가격"),
+                fieldWithPath("suggest").description("가격 제안 여부"),
+                fieldWithPath("description").description("상품 설명"),
+                fieldWithPath("place").description("거래 희망 장소"),
+                fieldWithPath("removePictures").description("삭제할 이미지 아이디")
+        );
+    }
+
+    private RequestPartsSnippet documentUpdateBoardRequestParts() {
+        return requestParts(
+                partWithName("updateRequest").description("게시글 수정 입력값"),
+                partWithName("newPictures").description("새 첨부사진")
+        );
+    }
+
+    private PathParametersSnippet documentUpdateBoardPathParameters() {
+        return pathParameters(
+                parameterWithName("id").description("수정할 게시글 ID")
+        );
+    }
+
+    public ResultHandler createDeleteBoardSuccessDocument() {
+        return restDocs.document(
+                documentDeleteBoardPathParameters(),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    private PathParametersSnippet documentDeleteBoardPathParameters() {
+        return pathParameters(
+                parameterWithName("id").description("삭제할 게시글 ID")
+        );
+    }
+
+    public ResultHandler createGetTmpBoardSuccessDocument() {
+        return restDocs.document(responseFields(createBoardDetailSuccessDescriptor()));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardTestHelper.java
@@ -1,0 +1,142 @@
+package com.carrot.carrotmarketclonecoding.board.helper.board;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import java.util.Map;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Import;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Import(value = {
+        BoardRequestHelper.class,
+        BoardRestDocsHelper.class
+})
+@TestComponent
+public class BoardTestHelper extends ControllerTestUtil {
+
+    private final BoardRequestHelper requestHelper;
+    private final BoardRestDocsHelper docsHelper;
+
+    public BoardTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new BoardRequestHelper(mvc);
+        this.docsHelper = new BoardRestDocsHelper(restDocs);
+    }
+
+    public void assertRegisterBoardSuccess(ResultFields resultFields,
+                                           MockMultipartFile request,
+                                           MockMultipartFile[] pictures) throws Exception {
+        assertRegisterBoard(resultFields, request, pictures, docsHelper.createRegisterBoardSuccessDocument());
+    }
+
+    public void assertRegisterBoardFailed(ResultFields resultFields,
+                                          MockMultipartFile request,
+                                           MockMultipartFile[] pictures) throws Exception {
+        assertRegisterBoard(resultFields, request, pictures, docsHelper.createCommonResponseDocument());
+    }
+
+    private void assertRegisterBoard(ResultFields resultFields,
+                                     MockMultipartFile request,
+                                     MockMultipartFile[] pictures,
+                                     RestDocumentationResultHandler restDocs) throws Exception {
+        assertResponseResult(
+                requestHelper.requestRegisterBoard(request, pictures), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocs);
+    }
+
+    public void assertRegisterTmpBoardSuccess(ResultFields resultFields,
+                                              MockMultipartFile request,
+                                              MockMultipartFile[] pictures) throws Exception {
+        assertResponseResult(requestHelper.requestRegisterTmpBoard(request, pictures), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createRegisterBoardSuccessDocument());
+    }
+
+    public void assertRegisterBoardFailedInvalidInput(ResultFields resultFields,
+                                                      MockMultipartFile request,
+                                                      MockMultipartFile[] pictures,
+                                                      Map<String, String> resultMap) throws Exception {
+        assertResponseResult(requestHelper.requestRegisterBoard(request, pictures), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(resultMap)))
+                .andDo(docsHelper.createRegisterBoardFailedInvalidInputDocument());
+    }
+
+    public void assertGetBoardDetailSuccess(ResultFields resultFields, String dataJsonPath, Object data) throws Exception {
+        assertResponseResult(requestHelper.requestGetBoardDetail(), resultFields)
+                .andExpect(jsonPath(dataJsonPath, equalTo(data)))
+                .andDo(docsHelper.createGetBoardDetailSuccessDocument());
+    }
+
+    public void assertGetBoardDetailFailed(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetBoardDetail(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createGetBoardDetailFailedDocument());
+    }
+
+    public void assertSearchBoardsSuccess(ResultFields resultFields, int contentSize) throws Exception {
+        assertSearchBoards(resultFields)
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(contentSize)))
+                .andDo(docsHelper.createSearchBoardsSuccessDocument());
+    }
+
+    public void assertSearchBoardsFailed(ResultFields resultFields) throws Exception {
+        assertSearchBoards(resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createSearchBoardsFailedDocument());
+    }
+
+    private ResultActions assertSearchBoards(ResultFields resultFields) throws Exception {
+        return assertResponseResult(requestHelper.requestGetSearchBoards(), resultFields);
+    }
+
+    public void assertSearchMyBoardsSuccess(ResultFields resultFields) throws Exception {
+        assertSearchMyBoards(resultFields)
+                .andExpect(jsonPath("$.data.contents.size()", equalTo(30)))
+                .andExpect(jsonPath("$.data.totalPage", equalTo(3)))
+                .andExpect(jsonPath("$.data.totalElements", equalTo(30)))
+                .andExpect(jsonPath("$.data.first", equalTo(true)))
+                .andExpect(jsonPath("$.data.last", equalTo(false)))
+                .andExpect(jsonPath("$.data.numberOfElements", equalTo(30)))
+                .andDo(docsHelper.createSearchMyBoardsSuccessDocument());
+    }
+
+    public void assertSearchMyBoardsFailed(ResultFields resultFields) throws Exception {
+        assertSearchMyBoards(resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createCommonResponseDocument());
+    }
+
+    private ResultActions assertSearchMyBoards(ResultFields resultFields) throws Exception {
+        return assertResponseResult(requestHelper.requestSearchMyBoards(), resultFields);
+    }
+
+    public void assertUpdateBoard(ResultFields resultFields, MockMultipartFile[] newPictures, MockMultipartFile updateRequest) throws Exception {
+        assertResponseResult(requestHelper.requestUpdateBoard(newPictures, updateRequest), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createUpdateBoardDocument());
+    }
+
+    public void assertDeleteBoard(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestDeleteBoard(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createDeleteBoardSuccessDocument());
+    }
+
+    public void assertGetTmpBoardDetailSuccess(ResultFields resultFields, String jsonPath, Object data) throws Exception {
+        assertResponseResult(requestHelper.requestGetTmpBoard(), resultFields)
+                .andExpect(jsonPath(jsonPath, equalTo(data)))
+                .andDo(docsHelper.createGetTmpBoardSuccessDocument());
+    }
+
+    public void assertTmpBoardDetailFailed(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetTmpBoard(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createCommonResponseDocument());
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRequestHelper.java
@@ -3,23 +3,28 @@ package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 
+import com.carrot.carrotmarketclonecoding.util.ControllerRequestUtil;
 import org.springframework.boot.test.context.TestComponent;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
 @TestComponent
-public class BoardLikeRequestHelper {
+public class BoardLikeRequestHelper extends ControllerRequestUtil {
+
+    private final MockMvc mvc;
+
+    public BoardLikeRequestHelper(MockMvc mvc) {
+        this.mvc = mvc;
+    }
 
     private static final String ADD_BOARD_LIKE_URL = "/board/like/{id}";
     private static final String GET_USER_LIKED_BOARDS_URL = "/board/like";
 
-    public ResultActions requestLikeBoard(MockMvc mvc) throws Exception {
-        return mvc.perform(post(ADD_BOARD_LIKE_URL, 1L)
-                .with(SecurityMockMvcRequestPostProcessors.csrf()));
+    public ResultActions requestLikeBoard() throws Exception {
+        return mvc.perform(requestWithCsrf(post(ADD_BOARD_LIKE_URL, 1L)));
     }
 
-    public ResultActions requestGetUserLikedBoards(MockMvc mvc) throws Exception {
+    public ResultActions requestGetUserLikedBoards() throws Exception {
         return mvc.perform(get(GET_USER_LIKED_BOARDS_URL).param("page", "0"));
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
@@ -15,21 +15,23 @@ import org.springframework.test.web.servlet.ResultHandler;
 @TestComponent
 public class BoardLikeRestDocsHelper extends RestDocsHelper {
 
-    public RestDocumentationResultHandler createAddBoardLikeDocument(RestDocumentationResultHandler restDocs) {
+    private final RestDocumentationResultHandler restDocs;
+
+    public BoardLikeRestDocsHelper(RestDocumentationResultHandler restDocs) {
+        this.restDocs = restDocs;
+    }
+
+    public RestDocumentationResultHandler createAddBoardLikeDocument() {
         return restDocs.document(
                 pathParameters(parameterWithName("id").description("게시글 ID")),
                 responseFields(createResponseResultDescriptor())
         );
     }
 
-    public ResultHandler createGetUserLikedBoardsSuccessDocument(RestDocumentationResultHandler restDocs) {
+    public ResultHandler createGetUserLikedBoardsSuccessDocument() {
         return restDocs.document(
-                queryParameters(
-                        parameterWithName("page").description("페이지번호")
-                ),
-                responseFields(
-                        createPageFieldsDescriptor(createContentsFieldDescriptor())
-                )
+                queryParameters(parameterWithName("page").description("페이지번호")),
+                responseFields(createPageFieldsDescriptor(createContentsFieldDescriptor()))
         );
     }
 
@@ -45,9 +47,7 @@ public class BoardLikeRestDocsHelper extends RestDocsHelper {
         };
     }
 
-    public ResultHandler createGetUserLikedBoardsFailedDocument(RestDocumentationResultHandler restDocs) {
-        return restDocs.document(
-                responseFields(createResponseResultDescriptor())
-        );
+    public ResultHandler createGetUserLikedBoardsFailedDocument() {
+        return restDocs.document(responseFields(createResponseResultDescriptor()));
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeTestHelper.java
@@ -3,58 +3,51 @@ package com.carrot.carrotmarketclonecoding.board.helper.boardlike;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
 import com.carrot.carrotmarketclonecoding.util.ResultFields;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Import;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.ResultActions;
 
+@Import(value = {
+        BoardLikeRequestHelper.class,
+        BoardLikeRestDocsHelper.class
+})
 @TestComponent
-public class BoardLikeTestHelper {
+public class BoardLikeTestHelper extends ControllerTestUtil {
 
-    @Autowired
-    private BoardLikeRequestHelper requestHelper;
+    private final BoardLikeRequestHelper requestHelper;
+    private final BoardLikeRestDocsHelper docsHelper;
 
-    @Autowired
-    private BoardLikeRestDocsHelper docsHelper;
-
-    public void assertLikeBoard(MockMvc mvc, ResultFields resultFields, RestDocumentationResultHandler restDocs)
-            throws Exception {
-        assertResponseResult(requestHelper.requestLikeBoard(mvc), resultFields)
-                .andExpect(jsonPath("$.data", equalTo(null)))
-                .andDo(docsHelper.createAddBoardLikeDocument(restDocs));
+    public BoardLikeTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new BoardLikeRequestHelper(mvc);
+        this.docsHelper = new BoardLikeRestDocsHelper(restDocs);
     }
 
-    public void assertGetUserLikedBoardsSuccess(MockMvc mvc,
-                                                ResultFields resultFields,
-                                                RestDocumentationResultHandler restDocs)
+    public void assertLikeBoard(ResultFields resultFields)
             throws Exception {
-        assertResponseResult(requestHelper.requestGetUserLikedBoards(mvc), resultFields)
+        assertResponseResult(requestHelper.requestLikeBoard(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createAddBoardLikeDocument());
+    }
+
+    public void assertGetUserLikedBoardsSuccess(ResultFields resultFields)
+            throws Exception {
+        assertResponseResult(requestHelper.requestGetUserLikedBoards(), resultFields)
                 .andExpect(jsonPath("$.data.contents.size()", equalTo(2)))
                 .andExpect(jsonPath("$.data.totalPage", equalTo(1)))
                 .andExpect(jsonPath("$.data.totalElements", equalTo(2)))
                 .andExpect(jsonPath("$.data.first", equalTo(true)))
                 .andExpect(jsonPath("$.data.last", equalTo(true)))
                 .andExpect(jsonPath("$.data.numberOfElements", equalTo(2)))
-                .andDo(docsHelper.createGetUserLikedBoardsSuccessDocument(restDocs));
+                .andDo(docsHelper.createGetUserLikedBoardsSuccessDocument());
     }
 
-    public void assertGetUserLikedBoardsFailed(MockMvc mvc,
-                                             ResultFields resultFields,
-                                             RestDocumentationResultHandler restDocs)
+    public void assertGetUserLikedBoardsFailed(ResultFields resultFields)
             throws Exception{
-        assertResponseResult(requestHelper.requestGetUserLikedBoards(mvc), resultFields)
+        assertResponseResult(requestHelper.requestGetUserLikedBoards(), resultFields)
                 .andExpect(jsonPath("$.data", equalTo(null)))
-                .andDo(docsHelper.createGetUserLikedBoardsFailedDocument(restDocs));
-    }
-
-    // TODO 분리
-    private ResultActions assertResponseResult(ResultActions resultActions, ResultFields resultFields) throws Exception {
-        return resultActions
-                .andExpect(resultFields.getResultMatcher())
-                .andExpect(jsonPath("$.status", equalTo(resultFields.getStatus())))
-                .andExpect(jsonPath("$.result", equalTo(resultFields.isResult())))
-                .andExpect(jsonPath("$.message", equalTo(resultFields.getMessage())));
+                .andDo(docsHelper.createGetUserLikedBoardsFailedDocument());
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerRequestUtil.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerRequestUtil.java
@@ -1,0 +1,28 @@
+package com.carrot.carrotmarketclonecoding.util;
+
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
+
+public class ControllerRequestUtil {
+
+    protected MockHttpServletRequestBuilder requestWithCsrfAndSetContentType(MockHttpServletRequestBuilder requestBuilder,
+                                                                             MediaType contentType) {
+        return requestWithCsrf(requestBuilder).contentType(contentType);
+    }
+
+    protected MockHttpServletRequestBuilder requestWithCsrf(MockHttpServletRequestBuilder requestBuilder) {
+        return requestBuilder.with(SecurityMockMvcRequestPostProcessors.csrf());
+    }
+
+    protected MockMultipartHttpServletRequestBuilder requestWithMultipartFiles(
+            MockMultipartHttpServletRequestBuilder requestBuilder,
+            MockMultipartFile[] files) {
+        for (MockMultipartFile file : files) {
+            requestBuilder.file(file);
+        }
+        return requestBuilder;
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerTestUtil.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/ControllerTestUtil.java
@@ -3,30 +3,9 @@ package com.carrot.carrotmarketclonecoding.util;
 import static org.hamcrest.Matchers.equalTo;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
-import org.springframework.test.web.servlet.request.MockMultipartHttpServletRequestBuilder;
 
 public class ControllerTestUtil {
-
-    protected MockMultipartHttpServletRequestBuilder requestMultipartFiles(MockMultipartHttpServletRequestBuilder requestBuilder,
-                                                                         MockMultipartFile[] pictures) {
-        for (MockMultipartFile picture : pictures) {
-            requestBuilder.file(picture);
-        }
-        return requestBuilder;
-    }
-
-    protected MockHttpServletRequestBuilder requestWithCsrfAndSetContentType(MockHttpServletRequestBuilder requestBuilder, MediaType contentType) {
-        return requestWithCsrf(requestBuilder).contentType(contentType);
-    }
-
-    protected MockHttpServletRequestBuilder requestWithCsrf(MockHttpServletRequestBuilder requestBuilder) {
-        return requestBuilder.with(SecurityMockMvcRequestPostProcessors.csrf());
-    }
 
     protected ResultActions assertResponseResult(ResultActions resultActions, ResultFields resultFields) throws Exception {
         return resultActions

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsTestUtil.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsTestUtil.java
@@ -1,7 +1,5 @@
 package com.carrot.carrotmarketclonecoding.util;
 
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,7 +9,6 @@ import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
-import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -21,7 +18,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 @Disabled
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
-public class RestDocsTestUtil extends ControllerTestUtil {
+public class RestDocsTestUtil {
 
     @Autowired
     protected MockMvc mvc;
@@ -37,15 +34,5 @@ public class RestDocsTestUtil extends ControllerTestUtil {
                 .alwaysDo(MockMvcResultHandlers.print())
                 .addFilters(new CharacterEncodingFilter("UTF-8", true))
                 .build();
-    }
-
-    // TODO remove
-    protected FieldDescriptor[] createResponseResultDescriptor() {
-        return new FieldDescriptor[] {
-                fieldWithPath("status").description("응답 상태"),
-                fieldWithPath("result").description("응답 결과"),
-                fieldWithPath("message").description("응답 메시지"),
-                fieldWithPath("data").description("응답 본문")
-        };
     }
 }


### PR DESCRIPTION
## 구현 기능
- [x] `BoardControllerTest` 테스트 코드에서 DTO 생성, MockMvc 요청, 문서화, 테스트 검증 클래스 분리
- [x] `BoardLikeControllerTest` 테스트 코드 리팩토링
    - [x] `BoardLikeRequestHelper`에 `MockMvc`를 생성자로 전달
    - [x] `BoardLikeRestDocsHelper`에 `restDocs` 생성자로 전달

## 관련 이슈
resolved #130
