### PR TITLE
[BUG] 임시저장게시글 조회 로직 수정

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/controller/BoardController.java
@@ -60,7 +60,7 @@ public class BoardController {
 
     @GetMapping("/{id}")
     public ResponseEntity<?> detail(@PathVariable("id") Long boardId, HttpServletRequest request) {
-        BoardDetailResponseDto boardDetail = boardService.detail(boardId, request);
+        BoardDetailResponseDto boardDetail = boardService.getBoardDetail(boardId, request);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_DETAIL_SUCCESS.getMessage(), boardDetail));
@@ -69,7 +69,7 @@ public class BoardController {
     @GetMapping("/tmp")
     public ResponseEntity<?> tmpDetail(@AuthenticationPrincipal LoginUser loginUser) {
         Long authId = Long.parseLong(loginUser.getUsername());
-        BoardDetailResponseDto boardDetail = boardService.tmpBoardDetail(authId);
+        BoardDetailResponseDto boardDetail = boardService.getTmpBoardDetail(authId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, BOARD_GET_TMP_SUCCESS.getMessage(), boardDetail));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardNotificationService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardNotificationService.java
@@ -1,0 +1,8 @@
+package com.carrot.carrotmarketclonecoding.board.service;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+
+public interface BoardNotificationService {
+    void sendKeywordNotification(BoardRegisterRequestDto registerRequestDto, Board board);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/BoardService.java
@@ -14,9 +14,9 @@ import org.springframework.web.multipart.MultipartFile;
 public interface BoardService {
     Long register(Long authId, BoardRegisterRequestDto registerRequestDto, MultipartFile[] pictures, boolean tmp);
 
-    BoardDetailResponseDto detail(Long boardId, HttpServletRequest request);
+    BoardDetailResponseDto getBoardDetail(Long boardId, HttpServletRequest request);
 
-    BoardDetailResponseDto tmpBoardDetail(Long memberId);
+    BoardDetailResponseDto getTmpBoardDetail(Long memberId);
 
     PageResponseDto<BoardSearchResponseDto> search(Long authId, BoardSearchRequestDto searchRequestDto, Pageable pageable);
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardNotificationServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardNotificationServiceImpl.java
@@ -1,0 +1,42 @@
+package com.carrot.carrotmarketclonecoding.board.service.impl;
+
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
+import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardNotificationResponseDto;
+import com.carrot.carrotmarketclonecoding.board.service.BoardNotificationService;
+import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
+import com.carrot.carrotmarketclonecoding.keyword.repository.KeywordRepository;
+import com.carrot.carrotmarketclonecoding.notification.domain.enums.NotificationType;
+import com.carrot.carrotmarketclonecoding.notification.service.NotificationService;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardNotificationServiceImpl implements BoardNotificationService {
+
+    private final KeywordRepository keywordRepository;
+    private final NotificationService notificationService;
+
+    @Override
+    public void sendKeywordNotification(BoardRegisterRequestDto registerRequestDto, Board board) {
+        Set<String> wordsNotDuplicated = getTitleAndDescriptionNotDuplicated(registerRequestDto);
+        Set<Keyword> keywords = keywordRepository.findByNameIn(wordsNotDuplicated);
+        BoardNotificationResponseDto notification = new BoardNotificationResponseDto(board);
+        sendBoardNotificationResponseDto(keywords, notification);
+    }
+
+    private Set<String> getTitleAndDescriptionNotDuplicated(BoardRegisterRequestDto registerRequestDto) {
+        String[] words = (registerRequestDto.getTitle() + " " + registerRequestDto.getDescription()).split(" ");
+        return new HashSet<>(List.of(words));
+    }
+
+    private void sendBoardNotificationResponseDto(Set<Keyword> keywords, BoardNotificationResponseDto notification) {
+        for (Keyword keyword : keywords) {
+            notificationService.add(keyword.getMember().getAuthId(), NotificationType.NOTICE, notification);
+        }
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -70,9 +70,8 @@ public class BoardServiceImpl implements BoardService {
         return board.getId();
     }
 
-    // TODO method name -> getBoardDetail
     @Override
-    public BoardDetailResponseDto detail(Long boardId, HttpServletRequest request) {
+    public BoardDetailResponseDto getBoardDetail(Long boardId, HttpServletRequest request) {
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         int like = boardLikeRepository.countByBoard(board);
 
@@ -89,10 +88,9 @@ public class BoardServiceImpl implements BoardService {
         return BoardDetailResponseDto.createBoardDetail(board, like);
     }
 
-    // TODO method name -> getTmpBoardDetail
     @Override
     @Transactional(readOnly = true)
-    public BoardDetailResponseDto tmpBoardDetail(Long authId) {
+    public BoardDetailResponseDto getTmpBoardDetail(Long authId) {
         Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         // TODO 임시게시글이 없을 경우 null을 반환하지 않고 예외를 발생
         Optional<Board> board = boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(member);

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -1,21 +1,20 @@
 package com.carrot.carrotmarketclonecoding.board.service.impl;
 
-import static com.carrot.carrotmarketclonecoding.board.domain.QBoard.board;
-
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.MyBoardSearchRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
-import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardNotificationResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardLikeRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardPictureRepository;
 import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
+import com.carrot.carrotmarketclonecoding.board.service.BoardNotificationService;
 import com.carrot.carrotmarketclonecoding.board.service.BoardService;
 import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordRedisService;
 import com.carrot.carrotmarketclonecoding.board.service.VisitRedisService;
+import com.carrot.carrotmarketclonecoding.board.util.HeaderUtil;
 import com.carrot.carrotmarketclonecoding.category.domain.Category;
 import com.carrot.carrotmarketclonecoding.category.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
@@ -24,16 +23,9 @@ import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundExcepti
 import com.carrot.carrotmarketclonecoding.common.exception.TmpBoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
-import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
-import com.carrot.carrotmarketclonecoding.keyword.repository.KeywordRepository;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
-import com.carrot.carrotmarketclonecoding.notification.domain.enums.NotificationType;
-import com.carrot.carrotmarketclonecoding.notification.service.NotificationService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -51,14 +43,10 @@ public class BoardServiceImpl implements BoardService {
     private final CategoryRepository categoryRepository;
     private final BoardPictureRepository boardPictureRepository;
     private final BoardLikeRepository boardLikeRepository;
-    private final KeywordRepository keywordRepository;
     private final VisitRedisService visitRedisService;
     private final SearchKeywordRedisService searchKeywordRedisService;
     private final BoardPictureService boardPictureService;
-    private final NotificationService notificationService;
-
-    private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
-    private static final String HEADER_USER_AGENT = "User-Agent";
+    private final BoardNotificationService boardNotificationService;
 
     @Override
     public Long register(Long authId, BoardRegisterRequestDto registerRequestDto, MultipartFile[] pictures, boolean tmp) {
@@ -68,7 +56,7 @@ public class BoardServiceImpl implements BoardService {
         board.setPriceZeroIfMethodIsShare();
         boardRepository.save(board);
         boardPictureService.uploadPicturesIfExistAndUnderLimit(pictures, board);
-        sendKeywordNotification(registerRequestDto, board);
+        boardNotificationService.sendKeywordNotification(registerRequestDto, board);
         return board.getId();
     }
 
@@ -77,9 +65,9 @@ public class BoardServiceImpl implements BoardService {
         Board board = boardRepository.findById(boardId).orElseThrow(BoardNotFoundException::new);
         int like = boardLikeRepository.countByBoard(board);
 
-        String ip = getClientIp(request);
+        String ip = HeaderUtil.getClientIp(request);
         log.debug("IP: {}", ip);
-        String userAgent = getUserAgent(request);
+        String userAgent = HeaderUtil.getUserAgent(request);
         log.debug("USER-AGENT: {}", userAgent);
         if (visitRedisService.increaseVisit(board.getId().toString(), ip, userAgent)) {
             board.increaseVisit();
@@ -159,38 +147,5 @@ public class BoardServiceImpl implements BoardService {
 
     private boolean isLogin(Long authId) {
         return authId != null && authId > 0L;
-    }
-
-    // TODO Util 클래스 분리
-    private String getClientIp(HttpServletRequest request) {
-        String ip = request.getHeader(HEADER_X_FORWARDED_FOR);
-        if (ip == null || ip.isEmpty()) {
-            ip = request.getRemoteAddr();
-        }
-        return ip;
-    }
-
-    // TODO Util 클래스 분리
-    private String getUserAgent(HttpServletRequest request) {
-        return request.getHeader(HEADER_USER_AGENT);
-    }
-
-    // TODO BoardNotificationService 클래스로 분리?
-    private void sendKeywordNotification(BoardRegisterRequestDto registerRequestDto, Board board) {
-        Set<String> wordsNotDuplicated = getTitleAndDescriptionNotDuplicated(registerRequestDto);
-        Set<Keyword> keywords = keywordRepository.findByNameIn(wordsNotDuplicated);
-        BoardNotificationResponseDto notification = new BoardNotificationResponseDto(board);
-        sendBoardNotificationResponseDto(keywords, notification);
-    }
-
-    private Set<String> getTitleAndDescriptionNotDuplicated(BoardRegisterRequestDto registerRequestDto) {
-        String[] words = (registerRequestDto.getTitle() + " " + registerRequestDto.getDescription()).split(" ");
-        return new HashSet<>(List.of(words));
-    }
-
-    private void sendBoardNotificationResponseDto(Set<Keyword> keywords, BoardNotificationResponseDto notification) {
-        for (Keyword keyword : keywords) {
-            notificationService.add(keyword.getMember().getAuthId(), NotificationType.NOTICE, notification);
-        }
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/service/impl/BoardServiceImpl.java
@@ -1,5 +1,7 @@
 package com.carrot.carrotmarketclonecoding.board.service.impl;
 
+import static com.carrot.carrotmarketclonecoding.board.domain.QBoard.board;
+
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardSearchRequestDto;
@@ -19,6 +21,7 @@ import com.carrot.carrotmarketclonecoding.category.repository.CategoryRepository
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.TmpBoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
@@ -30,7 +33,6 @@ import com.carrot.carrotmarketclonecoding.notification.service.NotificationServi
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -92,14 +94,9 @@ public class BoardServiceImpl implements BoardService {
     @Transactional(readOnly = true)
     public BoardDetailResponseDto getTmpBoardDetail(Long authId) {
         Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
-        // TODO 임시게시글이 없을 경우 null을 반환하지 않고 예외를 발생
-        Optional<Board> board = boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(member);
-
-        if (board.isPresent()) {
-            return BoardDetailResponseDto.createBoardDetail(board.get(), 0);
-        }
-
-        return null;
+        Board tmpBoard = boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(member)
+                .orElseThrow(TmpBoardNotFoundException::new);
+        return BoardDetailResponseDto.createBoardDetail(tmpBoard, 0);
     }
 
     @Override

--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/util/HeaderUtil.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/util/HeaderUtil.java
@@ -1,0 +1,21 @@
+package com.carrot.carrotmarketclonecoding.board.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class HeaderUtil {
+
+    private static final String HEADER_X_FORWARDED_FOR = "X-Forwarded-For";
+    private static final String HEADER_USER_AGENT = "User-Agent";
+
+    public static String getClientIp(HttpServletRequest request) {
+        String ip = request.getHeader(HEADER_X_FORWARDED_FOR);
+        if (ip == null || ip.isEmpty()) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+
+    public static String getUserAgent(HttpServletRequest request) {
+        return request.getHeader(HEADER_USER_AGENT);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/TmpBoardNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/TmpBoardNotFoundException.java
@@ -1,0 +1,17 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.TMP_BOARD_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class TmpBoardNotFoundException extends CustomException {
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return TMP_BOARD_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -1,6 +1,5 @@
 package com.carrot.carrotmarketclonecoding.common.response;
 
-import com.carrot.carrotmarketclonecoding.common.exception.KeywordNotFoundException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -10,6 +9,7 @@ public enum FailedMessage {
     MEMBER_NOT_FOUND("존재하지 않는 사용자입니다!"),
     CATEGORY_NOT_FOUND("존재하지 않는 카테고리입니다!"),
     BOARD_NOT_FOUND("존재하지 않는 게시글입니다!"),
+    TMP_BOARD_NOT_FOUND("임시저장된 게시글이 존재하지 않습니다!"),
     INPUT_NOT_VALID("입력값이 잘못되었습니다!"),
     FILE_EXTENSION_NOT_VALID("png 혹은 jpeg/jpg 파일이 아닙니다!"),
     FILE_UPLOAD_FAILED("파일 업로드에 실패하였습니다!"),

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -23,6 +23,7 @@ import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundExceptio
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.TmpBoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
@@ -502,18 +503,18 @@ class BoardControllerTest extends RestDocsTestUtil {
         }
 
         @Test
-        @DisplayName(SUCCESS_NO_TMP_BOARDS)
-        void getTmpBoardDetailSuccessNotTmpBoard() throws Exception {
+        @DisplayName(FAIL_TMP_BOARDS_NOT_FOUND)
+        void getTmpBoardDetailFailedTmpBoardNotFound() throws Exception {
             // given
             ResultFields resultFields = ResultFields.builder()
-                    .resultMatcher(status().isOk())
-                    .status(200)
-                    .result(true)
-                    .message(BOARD_GET_TMP_SUCCESS.getMessage())
+                    .resultMatcher(status().isBadRequest())
+                    .status(400)
+                    .result(false)
+                    .message(TMP_BOARD_NOT_FOUND.getMessage())
                     .build();
 
             // when
-            when(boardService.getTmpBoardDetail(anyLong())).thenReturn(null);
+            doThrow(TmpBoardNotFoundException.class).when(boardService).getTmpBoardDetail(anyLong());
 
             // then
             testHelper.assertTmpBoardDetailFailed(resultFields);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/BoardControllerTest.java
@@ -203,7 +203,7 @@ class BoardControllerTest extends RestDocsTestUtil {
                     .build();
 
             // when
-            when(boardService.detail(anyLong(), any())).thenReturn(response);
+            when(boardService.getBoardDetail(anyLong(), any())).thenReturn(response);
 
             // then
             testHelper.assertGetBoardDetailSuccess(resultFields, "$.data.id", boardId.intValue());
@@ -221,7 +221,7 @@ class BoardControllerTest extends RestDocsTestUtil {
                     .build();
 
             // when
-            when(boardService.detail(anyLong(), any())).thenThrow(new BoardNotFoundException());
+            when(boardService.getBoardDetail(anyLong(), any())).thenThrow(new BoardNotFoundException());
 
             // then
             testHelper.assertGetBoardDetailFailed(resultFields);
@@ -495,7 +495,7 @@ class BoardControllerTest extends RestDocsTestUtil {
                     .build();
 
             // when
-            when(boardService.tmpBoardDetail(anyLong())).thenReturn(response);
+            when(boardService.getTmpBoardDetail(anyLong())).thenReturn(response);
 
             // then
             testHelper.assertGetTmpBoardDetailSuccess(resultFields, "$.data.id", response.getId().intValue());
@@ -513,7 +513,7 @@ class BoardControllerTest extends RestDocsTestUtil {
                     .build();
 
             // when
-            when(boardService.tmpBoardDetail(anyLong())).thenReturn(null);
+            when(boardService.getTmpBoardDetail(anyLong())).thenReturn(null);
 
             // then
             testHelper.assertTmpBoardDetailFailed(resultFields);
@@ -531,7 +531,7 @@ class BoardControllerTest extends RestDocsTestUtil {
                     .build();
 
             // when
-            doThrow(MemberNotFoundException.class).when(boardService).tmpBoardDetail(anyLong());
+            doThrow(MemberNotFoundException.class).when(boardService).getTmpBoardDetail(anyLong());
 
             // then
             testHelper.assertTmpBoardDetailFailed(resultFields);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardTestDisplayNames.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/displayname/BoardTestDisplayNames.java
@@ -26,7 +26,7 @@ public enum BoardTestDisplayNames {
     SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS(MESSAGE.SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS),
     SUCCESS_DELETE_OLD_TMP_BOARDS(MESSAGE.SUCCESS_DELETE_OLD_TMP_BOARDS),
     SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP(MESSAGE.SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP),
-    SUCCESS_NO_TMP_BOARDS(MESSAGE.SUCCESS_NO_TMP_BOARDS),
+    FAIL_TMP_BOARDS_NOT_FOUND(MESSAGE.FAIL_TMP_BOARDS_NOT_FOUND),
     FAIL_INPUT_NOT_VALID(MESSAGE.FAIL_INPUT_NOT_VALID),
     FAIL_FILE_COUNT_OVER_10(MESSAGE.FAIL_FILE_COUNT_OVER_10),
     FAIL_WRITER_NOT_FOUND(MESSAGE.FAIL_WRITER_NOT_FOUND),
@@ -60,7 +60,6 @@ public enum BoardTestDisplayNames {
         public static final String SUCCESS_NOT_INCREASE_VISIT_REVISIT_IN_24HOURS = "성공 - 24시간내에 재조회할경우 조회수 증가 x";
         public static final String SUCCESS_DELETE_OLD_TMP_BOARDS = "성공 - 임시저장한 게시글을 수정한경우 이전 임시저장게시글 모두 삭제";
         public static final String SUCCESS_NOT_DELETE_OLD_TMP_BOARDS_IF_BOARD_NOT_TMP = "성공 - 임시저장한 게시글이 아닐경우 이전의 임시저장한 게시글을 삭제x";
-        public static final String SUCCESS_NO_TMP_BOARDS = "성공 - 임싯저장 게시글이 존재하지 않음";
         public static final String SUCCESS_REGISTER_TMP_BOARD = "성공 - 임시게시글 저장";
         public static final String FAIL_INPUT_NOT_VALID = "실패 - 유효성 검사 실패";
         public static final String FAIL_FILE_COUNT_OVER_10 = "실패 - 업로드 요청한 파일의 개수가 10개 초과";
@@ -68,6 +67,7 @@ public enum BoardTestDisplayNames {
         public static final String FAIL_MEMBER_NOT_FOUND = "실패 - 존재하지 않는 사용자";
         public static final String FAIL_CATEGORY_NOT_FOUND = "실패 - 존재하지 않는 카테고리";
         public static final String FAIL_BOARD_NOT_FOUND = "실패 - 존재하지 않는 게시판";
+        public static final String FAIL_TMP_BOARDS_NOT_FOUND = "실패 - 임시저장 게시글이 존재하지 않음";
         public static final String FAIL_MEMBER_IS_NOT_WRITER = "실패 - 작성자와 사용자가 일치하지 않음";
         public static final String FAIL_NEW_PICTURES_COUNT_OVER_10 = "실패 - 새로 첨부하는 사진의 개수가 10개를 넘음";
     }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardDtoFactory.java
@@ -1,5 +1,7 @@
 package com.carrot.carrotmarketclonecoding.board.helper.board;
 
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Status;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardRegisterRequestDto;
@@ -7,16 +9,20 @@ import com.carrot.carrotmarketclonecoding.board.dto.BoardRequestDto.BoardUpdateR
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardSearchResponseDto;
 import com.carrot.carrotmarketclonecoding.board.dto.validation.BoardRegisterValidationMessage.MESSAGE;
+import com.carrot.carrotmarketclonecoding.category.domain.Category;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 import org.springframework.boot.test.context.TestComponent;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.web.multipart.MultipartFile;
 import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @TestComponent
@@ -129,5 +135,42 @@ public class BoardDtoFactory {
 
     public PageResponseDto<BoardSearchResponseDto> createBoardSearchResponse(int page, int size, int total, List<BoardSearchResponseDto> searchResponseDtos) {
         return new PageResponseDto<>(new PageImpl<>(searchResponseDtos, PageRequest.of(page, size), total));
+    }
+
+    public MultipartFile[] createFiles(int size) {
+        return IntStream.range(0, size)
+                .mapToObj(i -> new MockMultipartFile(
+                        "file" + i,
+                        "file" + i + ".png",
+                        "text/png",
+                        ("Picture" + i).getBytes()
+                ))
+                .toArray(MultipartFile[]::new);
+    }
+
+    public List<BoardPicture> createBoardPictures(int size) {
+        List<BoardPicture> boardPictures = new ArrayList<>();
+        for (long i = 0; i < size; i++) {
+            boardPictures.add(BoardPicture.builder().id(i + 1).build());
+        }
+        return boardPictures;
+    }
+
+    public Board createMockBoard(Long boardId, Member mockMember, Category mockCategory, List<BoardPicture> boardPictures) {
+        return Board.builder()
+                .id(boardId)
+                .title("title")
+                .member(mockMember)
+                .category(mockCategory)
+                .method(Method.SELL)
+                .price(20000)
+                .suggest(false)
+                .description("description")
+                .place("place")
+                .visit(10)
+                .status(Status.SELL)
+                .tmp(false)
+                .boardPictures(boardPictures)
+                .build();
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -29,6 +29,7 @@ import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundExceptio
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.TmpBoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
@@ -222,7 +223,7 @@ class BoardServiceTest {
 
     @Nested
     @DisplayName(BOARD_DETAIL_SERVICE_TEST)
-    class BoardDetail {
+    class GetBoardDetail {
 
         @Test
         @DisplayName(SUCCESS_INCLUDE_INCREASE_VISIT)
@@ -337,7 +338,7 @@ class BoardServiceTest {
 
     @Nested
     @DisplayName(BOARD_MY_DETAIL_SERVICE_TEST)
-    class MyBoards {
+    class SearchMyBoards {
 
         @Test
         @DisplayName(SUCCESS)
@@ -648,7 +649,7 @@ class BoardServiceTest {
 
     @Nested
     @DisplayName(BOARD_GET_TMP_SERVICE_TEST)
-    class TmpBoardDetail {
+    class GetTmpBoardDetail {
 
         @Test
         @DisplayName(SUCCESS)
@@ -671,8 +672,8 @@ class BoardServiceTest {
         }
 
         @Test
-        @DisplayName(SUCCESS_NO_TMP_BOARDS)
-        void tmpBoardDetailSuccessNoTmpBoards() {
+        @DisplayName(FAIL_TMP_BOARDS_NOT_FOUND)
+        void tmpBoardDetailFailedNoTmpBoards() {
             // given
             Long memberId = 1L;
             Member mockMember = Member.builder().id(memberId).build();
@@ -680,10 +681,10 @@ class BoardServiceTest {
             when(boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(any())).thenReturn(Optional.empty());
 
             // when
-            BoardDetailResponseDto boardDetail = boardService.getTmpBoardDetail(memberId);
-
             // then
-            assertThat(boardDetail).isNull();
+            assertThatThrownBy(() -> boardService.getTmpBoardDetail(memberId))
+                    .isInstanceOf(TmpBoardNotFoundException.class)
+                    .hasMessage(TMP_BOARD_NOT_FOUND.getMessage());
         }
 
         @Test

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.*;
 
 import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.board.domain.BoardPicture;
-import com.carrot.carrotmarketclonecoding.board.dto.BoardResponseDto.BoardNotificationResponseDto;
+import com.carrot.carrotmarketclonecoding.board.helper.board.BoardDtoFactory;
 import com.carrot.carrotmarketclonecoding.category.domain.Category;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.Method;
 import com.carrot.carrotmarketclonecoding.board.domain.enums.SearchOrder;
@@ -32,20 +32,11 @@ import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundExcepti
 import com.carrot.carrotmarketclonecoding.common.exception.TmpBoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.UnauthorizedAccessException;
 import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
-import com.carrot.carrotmarketclonecoding.keyword.domain.Keyword;
-import com.carrot.carrotmarketclonecoding.keyword.repository.KeywordRepository;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
-import com.carrot.carrotmarketclonecoding.notification.domain.enums.NotificationType;
-import com.carrot.carrotmarketclonecoding.notification.service.NotificationService;
 import jakarta.servlet.http.HttpServletRequest;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -53,12 +44,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
@@ -92,13 +83,13 @@ class BoardServiceTest {
     private SearchKeywordRedisService searchKeywordRedisService;
 
     @Mock
-    private KeywordRepository keywordRepository;
-
-    @Mock
-    private NotificationService notificationService;
+    private BoardNotificationService boardNotificationService;
 
     @Mock
     private HttpServletRequest request;
+
+    @Spy
+    private BoardDtoFactory dtoFactory;
 
     @Nested
     @DisplayName(BOARD_REGISTER_SERVICE_TEST)
@@ -117,21 +108,9 @@ class BoardServiceTest {
             Category mockCategory = Category.builder().id(1L).build();
             when(categoryRepository.findById(anyLong())).thenReturn(Optional.of(mockCategory));
 
-            Set<Keyword> keywords = new HashSet<>(Arrays.asList(
-                    Keyword.builder()
-                            .member(Member.builder().authId(2222L).build())
-                            .name("keyword1")
-                            .build(),
-                    Keyword.builder()
-                            .member(Member.builder().authId(3333L).build())
-                            .name("keyword2")
-                            .build()
-            ));
-            when(keywordRepository.findByNameIn(anySet())).thenReturn(keywords);
-
             // when
-            BoardRegisterRequestDto boardRegisterRequestDto = createRegisterRequestDto();
-            MultipartFile[] pictures = createFiles(2);
+            BoardRegisterRequestDto boardRegisterRequestDto = dtoFactory.createRegisterRequestDto();
+            MultipartFile[] pictures = dtoFactory.createFiles(2);
             Long registerId = boardService.register(1111L, boardRegisterRequestDto, pictures, false);
 
             // then
@@ -142,14 +121,8 @@ class BoardServiceTest {
 
             verify(boardPictureService)
                     .uploadPicturesIfExistAndUnderLimit(eq(pictures), eq(capturedBoard));
-
-            ArgumentCaptor<BoardNotificationResponseDto> notificationCaptor = ArgumentCaptor
-                    .forClass(BoardNotificationResponseDto.class);
-            verify(notificationService, times(2))
-                    .add(anyLong(), any(NotificationType.class), notificationCaptor.capture());
-            BoardNotificationResponseDto notification = notificationCaptor.getValue();
-            assertThat(notification.getTitle()).isEqualTo(capturedBoard.getTitle());
-            assertThat(notification.getPrice()).isEqualTo(capturedBoard.getPrice());
+            verify(boardNotificationService, times(1))
+                    .sendKeywordNotification(boardRegisterRequestDto, capturedBoard);
         }
 
         @Test
@@ -173,7 +146,7 @@ class BoardServiceTest {
             // then
             BoardRegisterRequestDto boardRegisterRequestDto = new BoardRegisterRequestDto();
             boardRegisterRequestDto.setCategoryId(categoryId);
-            assertThatThrownBy(() -> boardService.register(memberId, boardRegisterRequestDto, createFiles(20), false))
+            assertThatThrownBy(() -> boardService.register(memberId, boardRegisterRequestDto, dtoFactory.createFiles(20), false))
                     .isInstanceOf(FileUploadLimitException.class)
                     .hasMessage(FILE_UPLOAD_LIMIT.getMessage());
         }
@@ -189,7 +162,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.register(memberId, createRegisterRequestDto(), createFiles(2), false))
+            assertThatThrownBy(() -> boardService.register(memberId, dtoFactory.createRegisterRequestDto(), dtoFactory.createFiles(2), false))
                     .isInstanceOf(CategoryNotFoundException.class)
                     .hasMessage(CATEGORY_NOT_FOUND.getMessage());
         }
@@ -203,21 +176,9 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.register(memberId, createRegisterRequestDto(), createFiles(2), false))
+            assertThatThrownBy(() -> boardService.register(memberId, dtoFactory.createRegisterRequestDto(), dtoFactory.createFiles(2), false))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
-        }
-
-        private BoardRegisterRequestDto createRegisterRequestDto() {
-            return BoardRegisterRequestDto.builder()
-                    .title("title")
-                    .categoryId(1L)
-                    .method(Method.SELL)
-                    .price(200000)
-                    .suggest(true)
-                    .description("description")
-                    .place("place")
-                    .build();
         }
     }
 
@@ -230,8 +191,10 @@ class BoardServiceTest {
         void boardDetailSuccess() {
             // given
             Long boardId = 1L;
-            List<BoardPicture> mockPictures = createBoardPictures(2);
-            Board mockBoard = createMockBoard(boardId, 1L, mockPictures);
+            Member mockMember = Member.builder().id(1L).nickname("member").build();
+            Category mockCategory = Category.builder().id(1L).name("category").build();
+            List<BoardPicture> mockPictures = dtoFactory.createBoardPictures(2);
+            Board mockBoard = dtoFactory.createMockBoard(boardId, mockMember, mockCategory, mockPictures);
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
             when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(true);
@@ -240,18 +203,21 @@ class BoardServiceTest {
             BoardDetailResponseDto result = boardService.getBoardDetail(boardId, request);
 
             // then
-            // todo
-            assertThat(result.getId()).isEqualTo(boardId);
-            assertThat(result.getTitle()).isEqualTo("title");
-            assertThat(result.getWriter()).isEqualTo("member");
-            assertThat(result.getCategory()).isEqualTo("category");
-            assertThat(result.getPrice()).isEqualTo(20000);
-            assertThat(result.getMethod()).isEqualTo(Method.SELL);
-            assertThat(result.getSuggest()).isEqualTo(false);
-            assertThat(result.getDescription()).isEqualTo("description");
-            assertThat(result.getPlace()).isEqualTo("place");
-            assertThat(result.getVisit()).isEqualTo(11);
-            assertThat(result.getStatus()).isEqualTo(Status.SELL);
+            assertBoardDetail(result, boardId);
+        }
+
+        private void assertBoardDetail(BoardDetailResponseDto boardDetail, Long boardId) {
+            assertThat(boardDetail.getId()).isEqualTo(boardId);
+            assertThat(boardDetail.getTitle()).isEqualTo("title");
+            assertThat(boardDetail.getWriter()).isEqualTo("member");
+            assertThat(boardDetail.getCategory()).isEqualTo("category");
+            assertThat(boardDetail.getPrice()).isEqualTo(20000);
+            assertThat(boardDetail.getMethod()).isEqualTo(Method.SELL);
+            assertThat(boardDetail.getSuggest()).isEqualTo(false);
+            assertThat(boardDetail.getDescription()).isEqualTo("description");
+            assertThat(boardDetail.getPlace()).isEqualTo("place");
+            assertThat(boardDetail.getVisit()).isEqualTo(11);
+            assertThat(boardDetail.getStatus()).isEqualTo(Status.SELL);
         }
 
         @Test
@@ -259,8 +225,10 @@ class BoardServiceTest {
         void boardDetailSuccessVisitCountNotIncreased() {
             // given
             Long boardId = 1L;
-            List<BoardPicture> mockPictures = createBoardPictures(2);
-            Board mockBoard = createMockBoard(1L, 1L, mockPictures);
+            Member mockMember = Member.builder().nickname("member").build();
+            Category mockCategory = Category.builder().name("category").build();
+            List<BoardPicture> mockPictures = dtoFactory.createBoardPictures(2);
+            Board mockBoard = dtoFactory.createMockBoard(boardId, mockMember, mockCategory, mockPictures);
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
             when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(false);
@@ -298,12 +266,8 @@ class BoardServiceTest {
             Member mockMember = Member.builder().id(memberId).build();
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
-            List<BoardSearchResponseDto> boardSearchResponses = Arrays.asList(
-                    new BoardSearchResponseDto(),
-                    new BoardSearchResponseDto()
-            );
             Pageable pageable = PageRequest.of(0, 10);
-            Page<BoardSearchResponseDto> searchResult = new PageImpl<>(boardSearchResponses, pageable, 2);
+            Page<BoardSearchResponseDto> searchResult = new PageImpl<>(dtoFactory.createBoardSearchResponseDtos(2), pageable, 2);
             when(boardRepository.findAllBySearchRequestDto(any(), any())).thenReturn(searchResult);
 
             // when
@@ -346,10 +310,7 @@ class BoardServiceTest {
             // given
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mock(Member.class)));
 
-            List<BoardSearchResponseDto> boardSearchResponses = Arrays.asList(
-                    new BoardSearchResponseDto(),
-                    new BoardSearchResponseDto()
-            );
+            List<BoardSearchResponseDto> boardSearchResponses = dtoFactory.createBoardSearchResponseDtos(2);
             Pageable pageable = PageRequest.of(0, 10);
             Page<BoardSearchResponseDto> searchResult = new PageImpl<>(boardSearchResponses, pageable, 2);
             when(boardRepository.findAllByStatusOrHide(any(), any(), any())).thenReturn(searchResult);
@@ -385,14 +346,15 @@ class BoardServiceTest {
         void updateBoardWithDeleteTmpBoardsSuccess() {
             // given
             Long memberId = 1L;
-            Member mockMember = Member.builder().id(1L).build();
+            Member mockMember = Member.builder().id(1L).authId(1111L).build();
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
             Long boardId = 1L;
+            Category mockCategory = Category.builder().id(2L).build();
             Board mockBoard = Board.builder()
                     .id(boardId)
                     .member(mockMember)
-                    .category(Category.builder().id(1L).build())
+                    .category(mockCategory)
                     .method(Method.SHARE)
                     .price(10000)
                     .suggest(true)
@@ -402,13 +364,12 @@ class BoardServiceTest {
                     .build();
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
 
-            Category mockCategory = Category.builder().id(2L).build();
             when(categoryRepository.findById(anyLong())).thenReturn(Optional.of(mockCategory));
 
             // when
-            BoardUpdateRequestDto updateRequestDto = createUpdateRequestDto();
+            BoardUpdateRequestDto updateRequestDto = dtoFactory.createUpdateRequestDto();
             updateRequestDto.setMethod(Method.SHARE);
-            MultipartFile[] newPictures = createFiles(2);
+            MultipartFile[] newPictures = dtoFactory.createFiles(2);
             boardService.update(boardId, memberId, updateRequestDto, newPictures);
 
             // then
@@ -418,8 +379,8 @@ class BoardServiceTest {
             assertThat(mockBoard.getPrice()).isEqualTo(0);
             assertThat(mockBoard.getCategory().getId()).isEqualTo(2L);
             assertThat(mockBoard.getSuggest()).isEqualTo(false);
-            assertThat(mockBoard.getDescription()).isEqualTo("updated description");
-            assertThat(mockBoard.getPlace()).isEqualTo("updated place");
+            assertThat(mockBoard.getDescription()).isEqualTo("It's my MacBook description");
+            assertThat(mockBoard.getPlace()).isEqualTo("Amsa");
         }
 
         @Test
@@ -432,23 +393,13 @@ class BoardServiceTest {
 
             Category mockCategory = Category.builder().id(1L).build();
             Long boardId = 1L;
-            Board mockBoard = Board.builder()
-                    .id(boardId)
-                    .member(mockMember)
-                    .category(mockCategory)
-                    .method(Method.SELL)
-                    .price(10000)
-                    .suggest(true)
-                    .description("description")
-                    .place("place")
-                    .tmp(false)
-                    .build();
+            Board mockBoard = dtoFactory.createMockBoard(boardId, mockMember, mockCategory, null);
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(categoryRepository.findById(anyLong())).thenReturn(Optional.of(mockCategory));
 
             // when
-            BoardUpdateRequestDto updateRequestDto = createUpdateRequestDto();
-            boardService.update(boardId, memberId, updateRequestDto, createFiles(2));
+            BoardUpdateRequestDto updateRequestDto = dtoFactory.createUpdateRequestDto();
+            boardService.update(boardId, memberId, updateRequestDto, dtoFactory.createFiles(2));
 
             // then
             verify(boardRepository, times(0)).deleteAllByMemberAndTmpIsTrueAndIdIsNot(mockMember, boardId);
@@ -462,7 +413,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.update(1L, 1L, createUpdateRequestDto(), createFiles(2)))
+            assertThatThrownBy(() -> boardService.update(1L, 1L, dtoFactory.createUpdateRequestDto(), dtoFactory.createFiles(2)))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
@@ -477,7 +428,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.update(1L, memberId, createUpdateRequestDto(), createFiles(2)))
+            assertThatThrownBy(() -> boardService.update(1L, memberId, dtoFactory.createUpdateRequestDto(), dtoFactory.createFiles(2)))
                     .isInstanceOf(BoardNotFoundException.class)
                     .hasMessage(BOARD_NOT_FOUND.getMessage());
         }
@@ -491,15 +442,12 @@ class BoardServiceTest {
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
             Long boardId = 1L;
-            Board mockBoard = Board.builder()
-                    .id(boardId)
-                    .member(Member.builder().id(2L).build())
-                    .build();
+            Board mockBoard = dtoFactory.createMockBoard(boardId, Member.builder().id(2L).build(), mock(Category.class), null);
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.update(boardId, memberId, createUpdateRequestDto(), createFiles(2)))
+            assertThatThrownBy(() -> boardService.update(boardId, memberId, dtoFactory.createUpdateRequestDto(), dtoFactory.createFiles(2)))
                     .isInstanceOf(UnauthorizedAccessException.class)
                     .hasMessage(UNAUTHORIZED_ACCESS.getMessage());
         }
@@ -523,7 +471,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.update(boardId, memberId, createUpdateRequestDto(), createFiles(2)))
+            assertThatThrownBy(() -> boardService.update(boardId, memberId, dtoFactory.createUpdateRequestDto(), dtoFactory.createFiles(2)))
                     .isInstanceOf(CategoryNotFoundException.class)
                     .hasMessage(CATEGORY_NOT_FOUND.getMessage());
         }
@@ -536,20 +484,14 @@ class BoardServiceTest {
             Member mockMember = Member.builder().id(memberId).build();
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
-            Long categoryId = 1L;
-            Category mockCategory = Category.builder().id(categoryId).build();
+            Category mockCategory = Category.builder().id(1L).build();
             Long boardId = 1L;
-            Board mockBoard = Board.builder()
-                    .id(boardId)
-                    .member(mockMember)
-                    .category(mockCategory)
-                    .tmp(false)
-                    .build();
+            Board mockBoard = dtoFactory.createMockBoard(boardId, mockMember, mockCategory, null);
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(categoryRepository.findById(anyLong())).thenReturn(Optional.of(mockCategory));
 
-            BoardUpdateRequestDto updateRequestDto = createUpdateRequestDto();
-            MultipartFile[] newPictures = createFiles(20);
+            BoardUpdateRequestDto updateRequestDto = dtoFactory.createUpdateRequestDto();
+            MultipartFile[] newPictures = dtoFactory.createFiles(20);
             doThrow(FileUploadLimitException.class).when(boardPictureService).uploadPicturesIfExistAndUnderLimit(newPictures, mockBoard);
 
             // when
@@ -557,19 +499,6 @@ class BoardServiceTest {
             assertThatThrownBy(() -> boardService.update(boardId, memberId, updateRequestDto, newPictures))
                     .isInstanceOf(FileUploadLimitException.class)
                     .hasMessage(FILE_UPLOAD_LIMIT.getMessage());
-        }
-
-        private BoardUpdateRequestDto createUpdateRequestDto() {
-            return BoardUpdateRequestDto.builder()
-                    .title("updated title")
-                    .categoryId(2L)
-                    .method(Method.SELL)
-                    .price(20000)
-                    .suggest(false)
-                    .description("updated description")
-                    .place("updated place")
-                    .removePictures(new Long[]{1L, 2L, 3L})
-                    .build();
         }
     }
 
@@ -660,8 +589,8 @@ class BoardServiceTest {
             when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
 
             Long boardId = 1L;
-            List<BoardPicture> mockPictures = createBoardPictures(2);
-            Board mockBoard = createMockBoard(boardId, memberId, mockPictures);
+            List<BoardPicture> mockPictures = dtoFactory.createBoardPictures(2);
+            Board mockBoard = dtoFactory.createMockBoard(boardId, mockMember, mock(Category.class), mockPictures);
             when(boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(any())).thenReturn(Optional.of(mockBoard));
 
             // when
@@ -699,42 +628,5 @@ class BoardServiceTest {
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }
-    }
-
-    private MultipartFile[] createFiles(int size) {
-        return IntStream.range(0, size)
-                .mapToObj(i -> new MockMultipartFile(
-                        "file" + i,
-                        "file" + i + ".png",
-                        "text/png",
-                        ("Picture" + i).getBytes()
-                ))
-                .toArray(MultipartFile[]::new);
-    }
-
-    private List<BoardPicture> createBoardPictures(int size) {
-        List<BoardPicture> boardPictures = new ArrayList<>();
-        for (long i = 0; i < size; i++) {
-            boardPictures.add(BoardPicture.builder().id(i + 1).build());
-        }
-        return boardPictures;
-    }
-
-    private Board createMockBoard(Long boardId, Long memberId, List<BoardPicture> boardPictures) {
-        return Board.builder()
-                .id(boardId)
-                .title("title")
-                .member(Member.builder().id(memberId).nickname("member").build())
-                .category(Category.builder().id(1L).name("category").build())
-                .method(Method.SELL)
-                .price(20000)
-                .suggest(false)
-                .description("description")
-                .place("place")
-                .visit(10)
-                .status(Status.SELL)
-                .tmp(false)
-                .boardPictures(boardPictures)
-                .build();
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -236,7 +236,7 @@ class BoardServiceTest {
             when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(true);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, request);
+            BoardDetailResponseDto result = boardService.getBoardDetail(boardId, request);
 
             // then
             // todo
@@ -265,7 +265,7 @@ class BoardServiceTest {
             when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(false);
 
             // when
-            BoardDetailResponseDto result = boardService.detail(boardId, request);
+            BoardDetailResponseDto result = boardService.getBoardDetail(boardId, request);
 
             // then
             assertThat(result.getVisit()).isEqualTo(10);
@@ -279,7 +279,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.detail(1L, request))
+            assertThatThrownBy(() -> boardService.getBoardDetail(1L, request))
                     .isInstanceOf(BoardNotFoundException.class)
                     .hasMessage(BOARD_NOT_FOUND.getMessage());
         }
@@ -664,7 +664,7 @@ class BoardServiceTest {
             when(boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(any())).thenReturn(Optional.of(mockBoard));
 
             // when
-            BoardDetailResponseDto boardDetail = boardService.tmpBoardDetail(memberId);
+            BoardDetailResponseDto boardDetail = boardService.getTmpBoardDetail(memberId);
 
             // then
             assertThat(boardDetail.getId()).isEqualTo(1L);
@@ -680,7 +680,7 @@ class BoardServiceTest {
             when(boardRepository.findFirstByMemberAndTmpIsTrueOrderByCreateDateDesc(any())).thenReturn(Optional.empty());
 
             // when
-            BoardDetailResponseDto boardDetail = boardService.tmpBoardDetail(memberId);
+            BoardDetailResponseDto boardDetail = boardService.getTmpBoardDetail(memberId);
 
             // then
             assertThat(boardDetail).isNull();
@@ -694,7 +694,7 @@ class BoardServiceTest {
 
             // when
             // then
-            assertThatThrownBy(() -> boardService.tmpBoardDetail(1L))
+            assertThatThrownBy(() -> boardService.getTmpBoardDetail(1L))
                     .isInstanceOf(MemberNotFoundException.class)
                     .hasMessage(MEMBER_NOT_FOUND.getMessage());
         }


### PR DESCRIPTION
## 구현 기능
- [x] 임시저장된 게시글이 존재하지 않을 경우 Null리턴이 아닌 예외 발생으로 수정
- [x] 임시저장 게시글 조회 실패 테스트 코드 수정
- [x] 임시저장된 게시글이 존재하지 않을 경우 발생할 커스텀 예외 클래스 생성
- [x] 테스트 케이스 Nested 클래스명 수정
- [x] 키워드알림전송 로직 분리
- [x] BoardServiceTest 테스트 코드 리팩토링
- [x] DTO 생성 컴포넌트 클래스 사용

## 관련 이슈
resolved #132 