### PR TITLE
사용자 검색 API 문서화 및 리팩토링

### DIFF
--- a/src/docs/asciidoc/board/searchKeyword.adoc
+++ b/src/docs/asciidoc/board/searchKeyword.adoc
@@ -1,0 +1,66 @@
+== SearchKeyword API
+
+=== 상위 인기검색어 조회
+회원, 비회원 모두 조회 가능
+
+==== CURL Request
+include::{snippets}/search-keyword-top-rank/search-keyword-top-rank-success/curl-request.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/search-keyword-top-rank/search-keyword-top-rank-success/response-fields.adoc[]
+include::{snippets}/search-keyword-top-rank/search-keyword-top-rank-success/response-body.adoc[]
+
+'''
+
+=== 사용자의 최근 검색어 목록 조회
+
+==== CURL Request
+include::{snippets}/recent-search-keywords/recent-search-keyword-success/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/recent-search-keywords/recent-search-keyword-success/http-request.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/recent-search-keywords/recent-search-keyword-success/response-fields.adoc[]
+include::{snippets}/recent-search-keywords/recent-search-keyword-success/response-body.adoc[]
+
+==== Response Body (401 - 존재하지 않는 사용자)
+include::{snippets}/recent-search-keywords/recent-search-keyword-fail-member-not-found/response-body.adoc[]
+
+'''
+
+=== 사용자의 특정 최근 검색내역 삭제
+
+==== CURL Request
+include::{snippets}/remove-recent-search-keyword/remove-recent-search-keyword-success/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/remove-recent-search-keyword/remove-recent-search-keyword-success/http-request.adoc[]
+
+==== Response Body (200 - 삭제 성공)
+정상 응답
+include::{snippets}/remove-recent-search-keyword/remove-recent-search-keyword-success/response-fields.adoc[]
+include::{snippets}/remove-recent-search-keyword/remove-recent-search-keyword-success/response-body.adoc[]
+
+==== Response Body (401 - 존재하지 않는 사용자)
+include::{snippets}/remove-recent-search-keyword/remove-recent-search-keyword-fail-member-not-found/response-body.adoc[]
+
+'''
+
+=== 사용자의 전체 최근 검색내역 삭제
+
+==== CURL Request
+include::{snippets}/remove-all-recent-search-keywords/remove-all-recent-search-keywords-success/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/remove-all-recent-search-keywords/remove-all-recent-search-keywords-success/http-request.adoc[]
+
+==== Response Body (200 - 삭제 성공)
+정상 응답
+include::{snippets}/remove-all-recent-search-keywords/remove-all-recent-search-keywords-success/response-fields.adoc[]
+include::{snippets}/remove-all-recent-search-keywords/remove-all-recent-search-keywords-success/response-body.adoc[]
+
+==== Response Body (401 - 존재하지 않는 사용자)
+include::{snippets}/remove-all-recent-search-keywords/remove-all-recent-search-keywords-fail-member-not-found/response-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -14,3 +14,4 @@ include::board/board.adoc[]
 
 include::board/boardLike.adoc[]
 
+include::board/searchKeyword.adoc[]

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/controller/SearchKeywordControllerTest.java
@@ -3,44 +3,44 @@ package com.carrot.carrotmarketclonecoding.board.controller;
 import static com.carrot.carrotmarketclonecoding.board.displayname.SearchKeywordTestDisplayNames.MESSAGE.*;
 import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
-import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
+import com.carrot.carrotmarketclonecoding.board.helper.searchkeyword.SearchKeywordTestHelper;
 import com.carrot.carrotmarketclonecoding.board.service.SearchKeywordService;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WithCustomMockUser
 @WebMvcTest(controllers = SearchKeywordController.class)
-class SearchKeywordControllerTest {
+class SearchKeywordControllerTest extends RestDocsTestUtil {
 
-    @Autowired
-    private MockMvc mvc;
+    private SearchKeywordTestHelper testHelper;
 
     @MockBean
     private SearchKeywordService searchKeywordService;
+
+    @BeforeEach
+    public void setUp() {
+        this.testHelper = new SearchKeywordTestHelper(mvc, restDocs);
+    }
 
     @Nested
     @DisplayName(SEARCH_KEYWORD_TOP_RANK_CONTROLLER_TEST)
@@ -53,19 +53,18 @@ class SearchKeywordControllerTest {
             Set<String> keywords = new HashSet<>();
             keywords.add("keyword1");
             keywords.add("keyword2");
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(GET_TOP_RANK_SEARCH_KEYWORDS_SUCCESS.getMessage())
+                    .build();
 
             // when
             when(searchKeywordService.getTopSearchKeywords()).thenReturn(keywords);
 
             // then
-            mvc.perform(get("/search/rank"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.result", equalTo(true)))
-                    .andExpect(jsonPath("$.message", equalTo(GET_TOP_RANK_SEARCH_KEYWORDS_SUCCESS.getMessage())))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data[0]", equalTo("keyword1")))
-                    .andExpect(jsonPath("$.data[1]", equalTo("keyword2")));
+            testHelper.assertSearchKeywordTopRankSuccess(resultFields);
         }
     }
 
@@ -78,36 +77,36 @@ class SearchKeywordControllerTest {
         void recentSearchKeywordSuccess() throws Exception {
             // given
             List<String> keywords = Arrays.asList("keyword1", "keyword2");
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(GET_RECENT_SEARCH_KEYWORDS_SUCCESS.getMessage())
+                    .build();
 
             // when
             when(searchKeywordService.getRecentSearchKeywords(anyLong())).thenReturn(keywords);
 
             // then
-            mvc.perform(get("/search/recent"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.result", equalTo(true)))
-                    .andExpect(jsonPath("$.message", equalTo(GET_RECENT_SEARCH_KEYWORDS_SUCCESS.getMessage())))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data[0]", equalTo("keyword1")))
-                    .andExpect(jsonPath("$.data[1]", equalTo("keyword2")));
+            testHelper.assertRecentSearchKeywordSuccess(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void recentSearchKeywordFailMemberNotFound() throws Exception {
             // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
 
             // when
             doThrow(MemberNotFoundException.class).when(searchKeywordService).getRecentSearchKeywords(anyLong());
 
             // then
-            mvc.perform(get("/search/recent"))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.status", equalTo(401)))
-                    .andExpect(jsonPath("$.result", equalTo(false)))
-                    .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
-                    .andExpect(jsonPath("$.data", equalTo(null)));
+            testHelper.assertRecentSearchKeywordFail(resultFields);
         }
     }
 
@@ -119,39 +118,36 @@ class SearchKeywordControllerTest {
         @DisplayName(SUCCESS)
         void removeRecentSearchKeywordSuccess() throws Exception {
             // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(REMOVE_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage())
+                    .build();
+
             // when
             doNothing().when(searchKeywordService).removeRecentSearchKeyword(anyLong(), anyString());
 
             // then
-            mvc.perform(delete("/search/recent")
-                            .with(SecurityMockMvcRequestPostProcessors.csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .param("keyword", "keyword"))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.result", equalTo(true)))
-                    .andExpect(jsonPath("$.message", equalTo(REMOVE_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage())))
-                    .andExpect(jsonPath("$.data", equalTo(null)));
+            testHelper.assertRemoveRecentSearchKeyword(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void removeRecentSearchKeywordFailMemberNotFound() throws Exception {
             // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
 
             // when
             doThrow(MemberNotFoundException.class).when(searchKeywordService).removeRecentSearchKeyword(anyLong(), any());
 
             // then
-            mvc.perform(delete("/search/recent")
-                            .with(SecurityMockMvcRequestPostProcessors.csrf())
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .param("keyword", "keyword"))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.status", equalTo(401)))
-                    .andExpect(jsonPath("$.result", equalTo(false)))
-                    .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
-                    .andExpect(jsonPath("$.data", equalTo(null)));
+            testHelper.assertRemoveRecentSearchKeyword(resultFields);
         }
     }
 
@@ -163,34 +159,36 @@ class SearchKeywordControllerTest {
         @DisplayName(SUCCESS)
         void removeAllRecentSearchKeywordsSuccess() throws Exception {
             // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(REMOVE_ALL_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage())
+                    .build();
+
             // when
             doNothing().when(searchKeywordService).removeAllRecentSearchKeywords(anyLong());
 
             // then
-            mvc.perform(delete("/search/recent/all")
-                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.status", equalTo(200)))
-                    .andExpect(jsonPath("$.result", equalTo(true)))
-                    .andExpect(jsonPath("$.message", equalTo(REMOVE_ALL_RECENT_SEARCH_KEYWORD_SUCCESS.getMessage())))
-                    .andExpect(jsonPath("$.data", equalTo(null)));
+            testHelper.assertRemoveAllRecentSearchKeywords(resultFields);
         }
 
         @Test
         @DisplayName(FAIL_MEMBER_NOT_FOUND)
         void removeAllRecentSearchKeywordsFailMemberNotFound() throws Exception {
             // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
+
             // when
             doThrow(MemberNotFoundException.class).when(searchKeywordService).removeAllRecentSearchKeywords(anyLong());
 
             // then
-            mvc.perform(delete("/search/recent/all")
-                            .with(SecurityMockMvcRequestPostProcessors.csrf()))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.status", equalTo(401)))
-                    .andExpect(jsonPath("$.result", equalTo(false)))
-                    .andExpect(jsonPath("$.message", equalTo(MEMBER_NOT_FOUND.getMessage())))
-                    .andExpect(jsonPath("$.data", equalTo(null)));
+            testHelper.assertRemoveAllRecentSearchKeywords(resultFields);
         }
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardRestDocsHelper.java
@@ -58,8 +58,8 @@ public class BoardRestDocsHelper extends RestDocsHelper {
         );
     }
 
-    public RestDocumentationResultHandler createCommonResponseDocument() {
-        return restDocs.document(responseFields(createResponseResultDescriptor()));
+    public ResultHandler createCommonResponseDocument() {
+        return createResponseResultDocument(restDocs);
     }
 
     public RestDocumentationResultHandler createRegisterBoardFailedInvalidInputDocument() {

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/board/BoardTestHelper.java
@@ -12,6 +12,7 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.ResultHandler;
 
 @Import(value = {
         BoardRequestHelper.class,
@@ -43,7 +44,7 @@ public class BoardTestHelper extends ControllerTestUtil {
     private void assertRegisterBoard(ResultFields resultFields,
                                      MockMultipartFile request,
                                      MockMultipartFile[] pictures,
-                                     RestDocumentationResultHandler restDocs) throws Exception {
+                                     ResultHandler restDocs) throws Exception {
         assertResponseResult(
                 requestHelper.requestRegisterBoard(request, pictures), resultFields)
                 .andExpect(jsonPath("$.data", equalTo(null)))

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/boardlike/BoardLikeRestDocsHelper.java
@@ -48,6 +48,6 @@ public class BoardLikeRestDocsHelper extends RestDocsHelper {
     }
 
     public ResultHandler createGetUserLikedBoardsFailedDocument() {
-        return restDocs.document(responseFields(createResponseResultDescriptor()));
+        return createResponseResultDocument(restDocs);
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordRequestHelper.java
@@ -1,0 +1,43 @@
+package com.carrot.carrotmarketclonecoding.board.helper.searchkeyword;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerRequestUtil;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@TestComponent
+public class SearchKeywordRequestHelper extends ControllerRequestUtil {
+
+    private final MockMvc mvc;
+
+    private static final String KEYWORD_TOP_RANK_URL = "/search/rank";
+    private static final String RECENT_SEARCH_KEYWORD_URL = "/search/recent";
+    private static final String REMOVE_ALL_RECENT_SEARCH_KEYWORDS_URL = "/search/recent/all";
+
+    public SearchKeywordRequestHelper(MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    public ResultActions requestGetKeywordTopRank() throws Exception {
+        return mvc.perform(get(KEYWORD_TOP_RANK_URL));
+    }
+
+    public ResultActions requestGetRecentSearchKeyword() throws Exception {
+        return mvc.perform(get(RECENT_SEARCH_KEYWORD_URL));
+    }
+
+    public ResultActions requestRemoveRecentSearchKeyword() throws Exception {
+        return mvc.perform(
+                requestWithCsrf(delete(RECENT_SEARCH_KEYWORD_URL + "?keyword=keyword"))
+        );
+    }
+
+    public ResultActions requestRemoveAllRecentSearchKeywords() throws Exception {
+        return mvc.perform(
+                requestWithCsrf(delete(REMOVE_ALL_RECENT_SEARCH_KEYWORDS_URL))
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordRestDocsHelper.java
@@ -1,0 +1,50 @@
+package com.carrot.carrotmarketclonecoding.board.helper.searchkeyword;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.request.QueryParametersSnippet;
+import org.springframework.test.web.servlet.ResultHandler;
+
+@TestComponent
+public class SearchKeywordRestDocsHelper extends RestDocsHelper {
+
+    private final RestDocumentationResultHandler restDocs;
+
+    public SearchKeywordRestDocsHelper(RestDocumentationResultHandler restDocs) {
+        this.restDocs = restDocs;
+    }
+
+    public ResultHandler createSearchKeywordSuccessDocument() {
+        return restDocs.document(
+                responseFields(
+                        fieldWithPath("status").description("응답 상태"),
+                        fieldWithPath("result").description("응답 결과"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data[]").description("키워드 목록")
+                )
+        );
+    }
+
+    public ResultHandler createRemoveRecentSearchKeywordDocument() {
+        return restDocs.document(
+                documentRemoveRecentSearchKeywordsQueryParameters(),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    private QueryParametersSnippet documentRemoveRecentSearchKeywordsQueryParameters() {
+        return queryParameters(
+                parameterWithName("keyword").description("키워드명")
+        );
+    }
+
+    public ResultHandler createResponseResultDocument() {
+        return createResponseResultDocument(restDocs);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/helper/searchkeyword/SearchKeywordTestHelper.java
@@ -1,0 +1,58 @@
+package com.carrot.carrotmarketclonecoding.board.helper.searchkeyword;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.context.annotation.Import;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@Import(value = {SearchKeywordRequestHelper.class, SearchKeywordRestDocsHelper.class})
+@TestComponent
+public class SearchKeywordTestHelper extends ControllerTestUtil {
+
+    private final SearchKeywordRequestHelper requestHelper;
+    private final SearchKeywordRestDocsHelper docsHelper;
+
+    public SearchKeywordTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new SearchKeywordRequestHelper(mvc);
+        this.docsHelper = new SearchKeywordRestDocsHelper(restDocs);
+    }
+
+    public void assertSearchKeywordTopRankSuccess(ResultFields resultFields) throws Exception {
+        assertSearchKeyword(requestHelper.requestGetKeywordTopRank(), resultFields);
+    }
+
+    public void assertRecentSearchKeywordSuccess(ResultFields resultFields) throws Exception {
+        assertSearchKeyword(requestHelper.requestGetRecentSearchKeyword(), resultFields);
+    }
+
+    private void assertSearchKeyword(ResultActions resultActions, ResultFields resultFields) throws Exception {
+        assertResponseResult(resultActions, resultFields)
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0]", equalTo("keyword1")))
+                .andExpect(jsonPath("$.data[1]", equalTo("keyword2")))
+                .andDo(docsHelper.createSearchKeywordSuccessDocument());
+    }
+
+    public void assertRecentSearchKeywordFail(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetRecentSearchKeyword(), resultFields)
+                .andDo(docsHelper.createResponseResultDocument());
+    }
+
+    public void assertRemoveRecentSearchKeyword(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestRemoveRecentSearchKeyword(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createRemoveRecentSearchKeywordDocument());
+    }
+
+    public void assertRemoveAllRecentSearchKeywords(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestRemoveAllRecentSearchKeywords(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(docsHelper.createResponseResultDocument());
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/util/RestDocsHelper.java
@@ -1,15 +1,24 @@
 package com.carrot.carrotmarketclonecoding.util;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.springframework.boot.test.context.TestComponent;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
 import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultHandler;
 
 @TestComponent
 public class RestDocsHelper {
+
+    protected ResultHandler createResponseResultDocument(RestDocumentationResultHandler restDocs) {
+        return restDocs.document(
+                responseFields(createResponseResultDescriptor())
+        );
+    }
 
     public FieldDescriptor[] createPageFieldsDescriptor(FieldDescriptor[] contentsDescriptors) {
         List<FieldDescriptor> fieldDescriptors = new ArrayList<>(Arrays.asList(


### PR DESCRIPTION
## 구현 기능
- [x] SearchKeywordControllerTest에 Spring REST Docs 적용
- [x] SearchKeywordControllerTest 테스트 코드 리팩토링 (여러개의 클래스로 분리)
- [x] BoardRestDocsHelper, BoardLikeRestDocsHelper의 중복 문서화 코드 제거

## 관련 이슈
resolved #134 