### PR TITLE
카테고리 API 문서화

### DIFF
--- a/src/docs/asciidoc/category/category.adoc
+++ b/src/docs/asciidoc/category/category.adoc
@@ -1,0 +1,14 @@
+== Category API
+
+=== 카테고리 목록 조회
+
+==== CURL Request
+include::{snippets}/category-controller-test/get-all-category/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/category-controller-test/get-all-category/http-request.adoc[]
+
+==== Response Body (200 - 저장 성공)
+정상 응답
+include::{snippets}/category-controller-test/get-all-category/response-fields.adoc[]
+include::{snippets}/category-controller-test/get-all-category/response-body.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,3 +15,5 @@ include::board/board.adoc[]
 include::board/boardLike.adoc[]
 
 include::board/searchKeyword.adoc[]
+
+include::category/category.adoc[]

--- a/src/test/java/com/carrot/carrotmarketclonecoding/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/category/controller/CategoryControllerTest.java
@@ -1,33 +1,36 @@
 package com.carrot.carrotmarketclonecoding.category.controller;
 
 import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.GET_CATEGORIES_SUCCESS;
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
 import com.carrot.carrotmarketclonecoding.category.dto.CategoryResponseDto;
+import com.carrot.carrotmarketclonecoding.category.helper.category.CategoryTestHelper;
 import com.carrot.carrotmarketclonecoding.category.service.impl.CategoryServiceImpl;
+import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
 import java.util.Arrays;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.web.servlet.MockMvc;
 
 @WithCustomMockUser
 @WebMvcTest(controllers = CategoryController.class)
-class CategoryControllerTest {
+class CategoryControllerTest extends RestDocsTestUtil {
 
-    @Autowired
-    private MockMvc mvc;
+    private CategoryTestHelper testHelper;
 
     @MockBean
     private CategoryServiceImpl categoryService;
+
+    @BeforeEach
+    void setUp() {
+        this.testHelper = new CategoryTestHelper(mvc, restDocs);
+    }
 
     @Test
     @DisplayName("카테고리 전체 목록 조회 테스트")
@@ -39,16 +42,17 @@ class CategoryControllerTest {
                 new CategoryResponseDto(3L, "category3")
         );
 
+        ResultFields resultFields = ResultFields.builder()
+                .resultMatcher(status().isOk())
+                .status(200)
+                .result(true)
+                .message(GET_CATEGORIES_SUCCESS.getMessage())
+                .build();
+
         // when
         when(categoryService.getAllCategory()).thenReturn(categories);
 
         // then
-        mvc.perform(get("/category"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status", equalTo(200)))
-                .andExpect(jsonPath("$.result", equalTo(true)))
-                .andExpect(jsonPath("$.message", equalTo(GET_CATEGORIES_SUCCESS.getMessage())))
-                .andExpect(jsonPath("$.data.size()", equalTo(3)));
-
+        testHelper.assertGetAllCategories(resultFields);
     }
 }

--- a/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryRequestHelper.java
@@ -1,0 +1,21 @@
+package com.carrot.carrotmarketclonecoding.category.helper.category;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class CategoryRequestHelper {
+
+    private static final String GET_ALL_CATEGORIES_URL = "/category";
+
+    private final MockMvc mvc;
+
+    public CategoryRequestHelper(MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    public ResultActions requestGetAllCategories() throws Exception {
+        return mvc.perform(get(GET_ALL_CATEGORIES_URL));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryRestDocsHelper.java
@@ -1,0 +1,30 @@
+package com.carrot.carrotmarketclonecoding.category.helper.category;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.ResultHandler;
+
+public class CategoryRestDocsHelper extends RestDocsHelper {
+
+    private final RestDocumentationResultHandler restDocs;
+
+    public CategoryRestDocsHelper(RestDocumentationResultHandler restDocs) {
+        this.restDocs = restDocs;
+    }
+
+    public ResultHandler createGetAllCategoriesDocument() {
+        return restDocs.document(
+                responseFields(
+                        fieldWithPath("status").description("응답 상태"),
+                        fieldWithPath("result").description("응답 결과"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data[]").description("응답 본문"),
+                        fieldWithPath("data[].id").description("카테고리 아이디"),
+                        fieldWithPath("data[].name").description("카테고리 이름")
+                )
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/category/helper/category/CategoryTestHelper.java
@@ -1,0 +1,25 @@
+package com.carrot.carrotmarketclonecoding.category.helper.category;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class CategoryTestHelper extends ControllerTestUtil {
+    private final CategoryRequestHelper requestHelper;
+    private final CategoryRestDocsHelper restDocsHelper;
+
+    public CategoryTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new CategoryRequestHelper(mvc);
+        this.restDocsHelper = new CategoryRestDocsHelper(restDocs);
+    }
+
+    public void assertGetAllCategories(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetAllCategories(), resultFields)
+                .andExpect(jsonPath("$.data.size()", equalTo(3)))
+                .andDo(restDocsHelper.createGetAllCategoriesDocument());
+    }
+}


### PR DESCRIPTION
## 구현 기능
- [x] CategoryControllerTest 리팩토링
  - CategoryRequestHelper에 MockMvc 요청 메서드 분리
  - CategoryRestDocsHelper에 카테고리 API 문서화 코드 분리
  - CategoryTestHelper에 테스트 검증 코드 분리

## 관련 이슈
resolved #136 