### PR TITLE
사용자 프로필 변경 & 조회 API 문서화

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -19,3 +19,5 @@ include::board/searchKeyword.adoc[]
 include::category/category.adoc[]
 
 include::keyword/keyword.adoc[]
+
+include::member/member.adoc[]

--- a/src/docs/asciidoc/member/member.adoc
+++ b/src/docs/asciidoc/member/member.adoc
@@ -1,0 +1,40 @@
+== Member API
+
+=== 사용자 프로필 변경
+
+==== CURL Request
+include::{snippets}/profile-update/update-success/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/profile-update/update-success/http-request.adoc[]
+
+==== Request Parts
+include::{snippets}/profile-update/update-success/request-parts.adoc[]
+include::{snippets}/profile-update/update-success/request-part-profileUpdateRequest-fields.adoc[]
+include::{snippets}/profile-update/update-success/request-part-profileUpdateRequest-body.adoc[]
+
+==== Response Body (200 - 수정 성공)
+정상 응답
+include::{snippets}/profile-update/update-success/response-fields.adoc[]
+include::{snippets}/profile-update/update-success/response-body.adoc[]
+
+==== Response Body (401 - 사용자가 존재하지 않음)
+include::{snippets}/profile-update/update-fail-member-not-found/response-body.adoc[]
+
+'''
+
+=== 사용자 프로필 조회
+
+==== CURL Request
+include::{snippets}/profile-detail/get-profile-detail-success/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/profile-detail/get-profile-detail-success/http-request.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/profile-detail/get-profile-detail-success/response-fields.adoc[]
+include::{snippets}/profile-detail/get-profile-detail-success/response-body.adoc[]
+
+==== Response Body (401 - 사용자가 존재하지 않음)
+include::{snippets}/profile-detail/get-profile-detail-fail-member-not-found/response-body.adoc[]

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/controller/MemberController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/controller/MemberController.java
@@ -13,10 +13,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/profile")
@@ -25,9 +26,11 @@ public class MemberController {
     private final MemberService memberService;
 
     @PatchMapping
-    public ResponseEntity<?> update(@AuthenticationPrincipal LoginUser loginUser, @ModelAttribute ProfileUpdateRequestDto profileUpdateRequestDto) {
+    public ResponseEntity<?> update(@AuthenticationPrincipal LoginUser loginUser,
+                                    @RequestPart("profileImage") MultipartFile profileImage,
+                                    @RequestPart("profileUpdateRequest") ProfileUpdateRequestDto profileUpdateRequest) {
         Long authId = Long.parseLong(loginUser.getUsername());
-        memberService.update(authId, profileUpdateRequestDto);
+        memberService.update(authId, profileImage, profileUpdateRequest);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ResponseResult.success(HttpStatus.OK, PROFILE_UPDATE_SUCCESS.getMessage(), null));

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/dto/ProfileDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/dto/ProfileDto.java
@@ -1,7 +1,6 @@
 package com.carrot.carrotmarketclonecoding.member.dto;
 
 import lombok.*;
-import org.springframework.web.multipart.MultipartFile;
 
 public class ProfileDto {
 
@@ -12,7 +11,6 @@ public class ProfileDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ProfileUpdateRequestDto {
-        private MultipartFile profileImage;
         private String nickname;
     }
 

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/service/MemberService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/service/MemberService.java
@@ -2,9 +2,9 @@ package com.carrot.carrotmarketclonecoding.member.service;
 
 import com.carrot.carrotmarketclonecoding.member.dto.ProfileDto.ProfileDetailResponseDto;
 import com.carrot.carrotmarketclonecoding.member.dto.ProfileDto.ProfileUpdateRequestDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface MemberService {
-    void update(Long authId, ProfileUpdateRequestDto profileUpdateRequestDto);
-
+    void update(Long authId, MultipartFile profileImage, ProfileUpdateRequestDto profileUpdateRequestDto);
     ProfileDetailResponseDto detail(Long authId);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/member/service/impl/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @Service
@@ -20,13 +21,13 @@ public class MemberServiceImpl implements MemberService {
     private final FileService fileService;
 
     @Override
-    public void update(Long authId, ProfileUpdateRequestDto profileUpdateRequestDto) {
+    public void update(Long authId, MultipartFile profileImage, ProfileUpdateRequestDto profileUpdateRequestDto) {
         Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
 
         fileService.deleteUploadedImage(member.getProfileUrl());
         String profileUrl = null;
-        if (profileUpdateRequestDto.getProfileImage() != null) {
-            profileUrl = fileService.uploadImage(profileUpdateRequestDto.getProfileImage());
+        if (profileImage != null) {
+            profileUrl = fileService.uploadImage(profileImage);
         }
 
         log.debug("new nickname: {}", profileUpdateRequestDto.getNickname());

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberDtoFactory.java
@@ -1,0 +1,36 @@
+package com.carrot.carrotmarketclonecoding.member.helper;
+
+import com.carrot.carrotmarketclonecoding.member.dto.ProfileDto.ProfileUpdateRequestDto;
+import org.springframework.boot.test.context.TestComponent;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
+
+@TestComponent
+public class MemberDtoFactory {
+
+    public MockMultipartFile createProfileImage() {
+        return new MockMultipartFile(
+                "profileImage",
+                "picture.png",
+                MediaType.IMAGE_JPEG_VALUE,
+                "picture".getBytes());
+    }
+
+    public ProfileUpdateRequestDto createProfileUpdateRequestDto() {
+        return ProfileUpdateRequestDto.builder()
+                .nickname("newNickname")
+                .build();
+    }
+
+    public MockMultipartFile createProfileUpdateRequest(ProfileUpdateRequestDto profileUpdateRequestDto)
+            throws Exception {
+        String profileUpdateRequestJson = new ObjectMapper().writeValueAsString(profileUpdateRequestDto);
+        return new MockMultipartFile(
+                "profileUpdateRequest",
+                "profileUpdateRequest.json",
+                "application/json",
+                profileUpdateRequestJson.getBytes()
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberRequestHelper.java
@@ -1,0 +1,39 @@
+package com.carrot.carrotmarketclonecoding.member.helper;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerRequestUtil;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class MemberRequestHelper extends ControllerRequestUtil {
+
+    private static final String MEMBER_REQUEST_URL = "/profile";
+
+    private final MockMvc mvc;
+
+    public MemberRequestHelper(MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    public ResultActions requestUpdateProfile(MockMultipartFile profileImage, MockMultipartFile updateRequest) throws Exception {
+        return mvc.perform(requestWithCsrfAndSetContentType(
+                        multipart(MEMBER_REQUEST_URL)
+                                .file(profileImage)
+                                .file(updateRequest)
+                                .with(request -> {
+                                    request.setMethod("PATCH");
+                                    return request;
+                                }),
+                        MediaType.MULTIPART_FORM_DATA
+                )
+        );
+    }
+
+    public ResultActions requestGetProfileDetail() throws Exception {
+        return mvc.perform(get(MEMBER_REQUEST_URL));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberRestDocsHelper.java
@@ -1,0 +1,51 @@
+package com.carrot.carrotmarketclonecoding.member.helper;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartBody;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestPartFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.ResultHandler;
+
+public class MemberRestDocsHelper extends RestDocsHelper {
+
+    private final RestDocumentationResultHandler restDocs;
+
+    public MemberRestDocsHelper(RestDocumentationResultHandler restDocs) {
+        this.restDocs = restDocs;
+    }
+
+    public ResultHandler createUpdateProfileSuccessDocument() {
+        return restDocs.document(
+                requestParts(
+                        partWithName("profileImage").description("수정할 프로필 사진"),
+                        partWithName("profileUpdateRequest").description("수정할 프로필 정보")
+                ),
+                requestPartBody("profileUpdateRequest"),
+                requestPartFields("profileUpdateRequest",
+                        fieldWithPath("nickname").description("수정할 닉네임")
+                ),
+                responseFields(createResponseResultDescriptor())
+        );
+    }
+
+    public ResultHandler createResponseResultDocument() {
+        return createResponseResultDocument(restDocs);
+    }
+
+    public ResultHandler createGetProfileDetailSuccessDocument() {
+        return restDocs.document(
+                responseFields(
+                        fieldWithPath("status").description("응답 상태"),
+                        fieldWithPath("result").description("응답 결과"),
+                        fieldWithPath("message").description("응답 메시지"),
+                        fieldWithPath("data.profileUrl").description("사용자의 프로필 URL"),
+                        fieldWithPath("data.nickname").description("사용자의 닉네임")
+                )
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/member/helper/MemberTestHelper.java
@@ -1,0 +1,55 @@
+package com.carrot.carrotmarketclonecoding.member.helper;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultHandler;
+
+public class MemberTestHelper extends ControllerTestUtil {
+
+    private final MemberRequestHelper requestHelper;
+    private final MemberRestDocsHelper restDocsHelper;
+
+    public MemberTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new MemberRequestHelper(mvc);
+        this.restDocsHelper = new MemberRestDocsHelper(restDocs);
+    }
+
+    public void assertUpdateProfileSuccess(ResultFields resultFields,
+                                           MockMultipartFile profileImage,
+                                           MockMultipartFile profileUpdateRequest) throws Exception {
+        assertUpdateProfile(resultFields, profileImage, profileUpdateRequest, restDocsHelper.createUpdateProfileSuccessDocument());
+    }
+
+    public void assertUpdateProfileFail(ResultFields resultFields,
+                                           MockMultipartFile profileImage,
+                                           MockMultipartFile profileUpdateRequest) throws Exception {
+        assertUpdateProfile(resultFields, profileImage, profileUpdateRequest, restDocsHelper.createResponseResultDocument());
+    }
+
+    private void assertUpdateProfile(ResultFields resultFields,
+                                        MockMultipartFile profileImage,
+                                        MockMultipartFile profileUpdateRequest,
+                                    ResultHandler document) throws Exception {
+        assertResponseResult(requestHelper.requestUpdateProfile(profileImage, profileUpdateRequest), resultFields)
+                .andDo(document);
+    }
+
+    public void assertGetProfileDetailSuccess(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetProfileDetail(), resultFields)
+                .andExpect(jsonPath("$.data.nickname", equalTo("nickname")))
+                .andExpect(jsonPath("$.data.profileUrl", equalTo("profileUrl")))
+                .andDo(restDocsHelper.createGetProfileDetailSuccessDocument());
+    }
+
+    public void assertGetProfileDetailFail(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetProfileDetail(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocsHelper.createResponseResultDocument());
+    }
+}


### PR DESCRIPTION
## PR 개요
사용자 프로필 변경 & 조회 API 문서화 및 테스트 코드 리팩토링

## 내용(에러내용)
- 사용자 프로필 API Spring REST Docs 적용
- MemberControllerTest 테스트 코드 리팩토링
- MemberTestHelper 클래스로 테스트 검증 로직 분리
- MemberRestDocsHelper 클래스로 문서화 로직 분리
- MemberDtoFactory 클래스로 DTO 생성 로직 분리

## 참고 이슈
resolved #138 

## 스크린샷

## 참고자료
