### PR TITLE
웹소켓 채팅 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,12 @@ dependencies {
     // Spring REST Docs
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+
+    // WebSocket
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 }
 
 ext {

--- a/src/docs/asciidoc/chat/chat.adoc
+++ b/src/docs/asciidoc/chat/chat.adoc
@@ -1,0 +1,89 @@
+== Chat API
+
+=== 채팅방 개설
+
+==== CURL Request
+include::{snippets}/create-chat-room-tests/create-chat-room-test/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/create-chat-room-tests/create-chat-room-test/http-request.adoc[]
+
+==== Response Body (201 - 저장 성공)
+include::{snippets}/create-chat-room-tests/create-chat-room-test/response-fields.adoc[]
+include::{snippets}/create-chat-room-tests/create-chat-room-test/response-body.adoc[]
+
+==== Response Body (401 - 사용자/수신자가 존재하지 않음)
+include::{snippets}/create-chat-room-tests/create-chat-room_-sender-or-receiver-not-found-test/response-body.adoc[]
+
+'''
+
+=== 채팅방 목록 조회
+
+==== CURL Request
+include::{snippets}/get-chat-rooms-tests/get-chat-rooms-test/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/get-chat-rooms-tests/get-chat-rooms-test/http-request.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/get-chat-rooms-tests/get-chat-rooms-test/response-fields.adoc[]
+include::{snippets}/get-chat-rooms-tests/get-chat-rooms-test/response-body.adoc[]
+
+==== Response Body (401 - 사용자가 존재하지 않음)
+include::{snippets}/get-chat-rooms-tests/get-chat-rooms_-member-not-found-test/response-body.adoc[]
+
+'''
+
+=== 채팅방의 이전 채팅 내역 조회
+
+==== CURL Request
+include::{snippets}/get-chat-messages-tests/get-chat-messages-test/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/get-chat-messages-tests/get-chat-messages-test/http-request.adoc[]
+
+==== Path Variables
+include::{snippets}/get-chat-messages-tests/get-chat-messages-test/path-parameters.adoc[]
+
+==== Response Body (200 - 조회 성공)
+정상 응답
+include::{snippets}/get-chat-messages-tests/get-chat-messages-test/response-fields.adoc[]
+include::{snippets}/get-chat-messages-tests/get-chat-messages-test/response-body.adoc[]
+
+==== Response Body (401 - 사용자가 존재하지 않음)
+include::{snippets}/get-chat-messages-tests/get-chat-messages_-not-member-of-chat-room-test/response-body.adoc[]
+
+==== Response Body (403 - 사용자의 채팅방이 아님)
+include::{snippets}/get-chat-messages-tests/get-chat-messages_-not-member-of-chat-room-test/response-body.adoc[]
+
+==== Response Body (400 - 채팅방이 존재하지 않음)
+include::{snippets}/get-chat-messages-tests/get-chat-messages_-chat-room-not-found-test/response-body.adoc[]
+
+'''
+
+=== 채팅방 삭제
+
+==== CURL Request
+include::{snippets}/delete-chat-room-tests/delete-chat-room-test/curl-request.adoc[]
+
+==== Http Request
+include::{snippets}/delete-chat-room-tests/delete-chat-room-test/http-request.adoc[]
+
+==== Path Variables
+include::{snippets}/delete-chat-room-tests/delete-chat-room-test/path-parameters.adoc[]
+
+==== Response Body (200 - 삭제 성공)
+정상 응답
+include::{snippets}/delete-chat-room-tests/delete-chat-room-test/response-fields.adoc[]
+include::{snippets}/delete-chat-room-tests/delete-chat-room-test/response-body.adoc[]
+
+==== Response Body (401 - 사용자가 존재하지 않음)
+include::{snippets}/delete-chat-room-tests/delete-chat-room_-member-not-found-test/response-body.adoc[]
+
+==== Response Body (403 - 사용자의 채팅방이 아님)
+include::{snippets}/delete-chat-room-tests/delete-chat-room_-user-is-not-owner-test/response-body.adoc[]
+
+==== Response Body (400 - 채팅방이 존재하지 않음)
+include::{snippets}/delete-chat-room-tests/delete-chat-room_-chat-room-not-found-test/response-body.adoc[]
+

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -25,3 +25,5 @@ include::member/member.adoc[]
 include::notification/notification.adoc[]
 
 include::word/word.adoc[]
+
+include::chat/chat.adoc[]

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatController.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatController.java
@@ -1,0 +1,75 @@
+package com.carrot.carrotmarketclonecoding.chat.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.CREATE_CHAT_ROOM_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.DELETE_CHAT_ROOM_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.GET_CHAT_MESSAGES_SUCCESS;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.GET_CHAT_ROOMS_SUCCESS;
+
+import com.carrot.carrotmarketclonecoding.auth.dto.LoginUser;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatMessageService;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatRoomService;
+import com.carrot.carrotmarketclonecoding.common.response.ResponseResult;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequestMapping("/chat/room")
+@RestController
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatRoomService chatRoomService;
+    private final ChatMessageService chatMessageService;
+
+    @PostMapping
+    public ResponseEntity<?> createChatRoom(@AuthenticationPrincipal LoginUser loginUser,
+                                            @RequestBody ChatRoomCreateRequestDto chatRoomCreateRequestDto) {
+        // TODO use Login User
+//        String roomNum = chatRoomService.create(Long.parseLong(loginUser.getUsername()), chatRoomCreateRequestDto);
+        String roomNum = chatRoomService.create(chatRoomCreateRequestDto.getSenderId(), chatRoomCreateRequestDto);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ResponseResult.success(HttpStatus.CREATED, CREATE_CHAT_ROOM_SUCCESS.getMessage(), roomNum));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getChatRooms(@AuthenticationPrincipal LoginUser loginUser) {
+        List<ChatRoomResponseDto> chatRooms = chatRoomService.getChatRooms(Long.parseLong(loginUser.getUsername()));
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, GET_CHAT_ROOMS_SUCCESS.getMessage(), chatRooms));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getChatMessages(@AuthenticationPrincipal LoginUser loginUser,
+                                             @PathVariable("id") Long chatRoomId) {
+        List<ChatMessageResponseDto> chatMessages = chatMessageService.getChatMessages(
+                Long.parseLong(loginUser.getUsername()), chatRoomId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, GET_CHAT_MESSAGES_SUCCESS.getMessage(), chatMessages));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteChatRoom(@AuthenticationPrincipal LoginUser loginUser,
+                                            @PathVariable("id") Long chatRoomId) {
+        chatRoomService.delete(Long.parseLong(loginUser.getUsername()), chatRoomId);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ResponseResult.success(HttpStatus.OK, DELETE_CHAT_ROOM_SUCCESS.getMessage(), null));
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatMessage.java
@@ -1,0 +1,23 @@
+package com.carrot.carrotmarketclonecoding.chat.domain;
+
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Builder
+@Getter
+@ToString
+@Document(collection = "chat_message")
+public class ChatMessage {
+
+    @Id
+    private String id;
+    private Long senderId;
+    private Long receiverId;
+    private String message;
+    private String roomNum;
+    private LocalDateTime createDate;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatRoom.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatRoom.java
@@ -1,0 +1,32 @@
+package com.carrot.carrotmarketclonecoding.chat.domain;
+
+import com.carrot.carrotmarketclonecoding.common.BaseEntity;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import lombok.*;
+
+@Getter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ChatRoom extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String roomNum;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member receiver;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatMessageRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatMessageRequestDto.java
@@ -1,0 +1,16 @@
+package com.carrot.carrotmarketclonecoding.chat.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageRequestDto {
+    private Long senderId;
+    private Long receiverId;
+    private String message;
+    private String roomNum;
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatMessageResponseDto.java
@@ -1,0 +1,30 @@
+package com.carrot.carrotmarketclonecoding.chat.dto;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatMessageResponseDto {
+    private String id;
+    private String roomNum;
+    private Long senderId;
+    private Long receiverId;
+    private String message;
+    private LocalDateTime createDate;
+
+    public ChatMessageResponseDto(ChatMessage chatMessage) {
+        this.id = chatMessage.getId();
+        this.roomNum = chatMessage.getRoomNum();
+        this.senderId = chatMessage.getSenderId();
+        this.receiverId = chatMessage.getReceiverId();
+        this.message = chatMessage.getMessage();
+        this.createDate = chatMessage.getCreateDate();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomRequestDto.java
@@ -1,0 +1,17 @@
+package com.carrot.carrotmarketclonecoding.chat.dto;
+
+import lombok.*;
+
+public class ChatRoomRequestDto {
+
+    @Getter
+    @Setter
+    @Builder
+    @ToString
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatRoomCreateRequestDto {
+        private Long senderId;  // TODO remove field senderId
+        private Long receiverId;
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomResponseDto.java
@@ -1,0 +1,25 @@
+package com.carrot.carrotmarketclonecoding.chat.dto;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChatRoomResponseDto {
+    private Long id;
+    private String roomNum;
+    private LocalDateTime createDate;
+
+    public static ChatRoomResponseDto createChatRoomResponseDto(ChatRoom chatRoom) {
+        return ChatRoomResponseDto.builder()
+                .id(chatRoom.getId())
+                .roomNum(chatRoom.getRoomNum())
+                .createDate(chatRoom.getCreateDate())
+                .build();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,11 @@
+package com.carrot.carrotmarketclonecoding.chat.repository;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatMessage;
+import java.util.List;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ChatMessageRepository extends MongoRepository<ChatMessage, String> {
+    void deleteAllByRoomNum(String roomNum);
+
+    List<ChatMessage> findAllByRoomNumOrderByCreateDateDesc(String roomNum);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,15 @@
+package com.carrot.carrotmarketclonecoding.chat.repository;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+    List<ChatRoom> findAllBySender(Member sender);
+
+    List<ChatRoom> findAllByReceiver(Member receiver);
+
+    Optional<ChatRoom> findByRoomNum(String roomNum);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/ChatMessageService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/ChatMessageService.java
@@ -1,0 +1,14 @@
+package com.carrot.carrotmarketclonecoding.chat.service;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import java.util.List;
+
+public interface ChatMessageService {
+
+    void save(ChatMessageRequestDto chatMessageRequestDto);
+
+    List<ChatMessageResponseDto> getChatMessages(Long authId, Long chatRoomId);
+
+    void deleteAll(String roomNum);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/ChatRoomService.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/ChatRoomService.java
@@ -1,0 +1,16 @@
+package com.carrot.carrotmarketclonecoding.chat.service;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import java.util.List;
+
+public interface ChatRoomService {
+
+    String create(Long authId, ChatRoomCreateRequestDto createRequestDto);
+
+    List<ChatRoomResponseDto> getChatRooms(Long authId);
+
+    void delete(Long authId, Long chatRoomId);
+
+    void validateChatRoom(String roomNum, Long senderId, Long receiverId);
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatMessageServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatMessageServiceImpl.java
@@ -1,0 +1,66 @@
+package com.carrot.carrotmarketclonecoding.chat.service.impl;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatMessage;
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatMessageRepository;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatMessageService;
+import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatMessageServiceImpl implements ChatMessageService {
+
+    private final MemberRepository memberRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    public void save(ChatMessageRequestDto chatMessageRequestDto) {
+        Member sender = memberRepository.findByAuthId(chatMessageRequestDto.getSenderId()).orElseThrow(MemberNotFoundException::new);
+        Member receiver = memberRepository.findByAuthId(chatMessageRequestDto.getReceiverId()).orElseThrow(MemberNotFoundException::new);
+        ChatMessage message = ChatMessage.builder()
+                .senderId(sender.getAuthId())
+                .receiverId(receiver.getAuthId())
+                .message(chatMessageRequestDto.getMessage())
+                .roomNum(chatMessageRequestDto.getRoomNum())
+                .createDate(LocalDateTime.now())
+                .build();
+        chatMessageRepository.save(message);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatMessageResponseDto> getChatMessages(Long authId, Long chatRoomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(ChatRoomNotFoundException::new);
+        validateMemberOfChatRoom(authId, chatRoom);
+        List<ChatMessage> chatMessages = chatMessageRepository.findAllByRoomNumOrderByCreateDateDesc(chatRoom.getRoomNum());
+        return chatMessages.stream().map(ChatMessageResponseDto::new).collect(Collectors.toList());
+    }
+
+    private void validateMemberOfChatRoom(Long authId, ChatRoom chatRoom) {
+        if (!authId.equals(chatRoom.getSender().getAuthId()) && !authId.equals(chatRoom.getReceiver().getAuthId())) {
+            throw new NotMemberOfChatRoomException();
+        }
+    }
+
+    @Override
+    public void deleteAll(String roomNum) {
+        chatMessageRepository.deleteAllByRoomNum(roomNum);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,0 +1,93 @@
+package com.carrot.carrotmarketclonecoding.chat.service.impl;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatMessageService;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatRoomService;
+import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.common.exception.UserNotOwnerOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+    private final MemberRepository memberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageService chatMessageService;
+
+    @Override
+    public String create(Long authId, ChatRoomCreateRequestDto createRequestDto) {
+        Member sender = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        Member receiver = memberRepository.findByAuthId(createRequestDto.getReceiverId()).orElseThrow(MemberNotFoundException::new);
+
+        String roomNum = UUID.randomUUID().toString();
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomNum(roomNum)
+                .sender(sender)
+                .receiver(receiver)
+                .build();
+        chatRoomRepository.save(chatRoom);
+        return roomNum;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ChatRoomResponseDto> getChatRooms(Long authId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        List<ChatRoom> chatRoomsSended = chatRoomRepository.findAllBySender(member);
+        List<ChatRoom> chatRoomsReceived = chatRoomRepository.findAllByReceiver(member);
+        return Stream.concat(
+                        chatRoomsSended.stream().map(ChatRoomResponseDto::createChatRoomResponseDto),
+                        chatRoomsReceived.stream().map(ChatRoomResponseDto::createChatRoomResponseDto)
+                )
+                .sorted((d1, d2) -> d2.getCreateDate().compareTo(d1.getCreateDate()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public void delete(Long authId, Long chatRoomId) {
+        Member member = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
+        ChatRoom chatRoom = chatRoomRepository.findById(chatRoomId).orElseThrow(ChatRoomNotFoundException::new);
+        validateSenderOfChatRoom(chatRoom, member);
+        chatMessageService.deleteAll(chatRoom.getRoomNum());
+        chatRoomRepository.delete(chatRoom);
+    }
+
+    private void validateSenderOfChatRoom(ChatRoom chatRoom, Member sender) {
+        if (chatRoom.getSender() != sender) {
+            throw new UserNotOwnerOfChatRoomException();
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public void validateChatRoom(String roomNum, Long senderId, Long receiverId) {
+        ChatRoom chatRoom = chatRoomRepository.findByRoomNum(roomNum).orElseThrow(ChatRoomNotFoundException::new);
+        validateSenderAndReceiverOfChatRoom(chatRoom, senderId, receiverId);
+    }
+
+    public void validateSenderAndReceiverOfChatRoom(ChatRoom chatRoom, Long senderId, Long receiverId) {
+        Long savedSenderId = chatRoom.getSender().getAuthId();
+        Long savedReceiverId = chatRoom.getReceiver().getAuthId();
+        if (!savedSenderId.equals(senderId) && !savedSenderId.equals(receiverId)) {
+            throw new NotMemberOfChatRoomException();
+        }
+        if (!savedReceiverId.equals(receiverId) && !savedReceiverId.equals(senderId)) {
+            throw new NotMemberOfChatRoomException();
+        }
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/websocket/WebSocketConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/websocket/WebSocketConfig.java
@@ -1,0 +1,26 @@
+package com.carrot.carrotmarketclonecoding.chat.websocket;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.WebSocketHandler;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final WebSocketHandler webSocketHandler;
+
+    @Value("${websocket.origin}")
+    private String origin;
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(webSocketHandler, "/chat")
+                .setAllowedOrigins(origin);
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/websocket/WebSocketHandler.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/websocket/WebSocketHandler.java
@@ -1,0 +1,136 @@
+package com.carrot.carrotmarketclonecoding.chat.websocket;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatMessageService;
+import com.carrot.carrotmarketclonecoding.chat.service.ChatRoomService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketHandler extends TextWebSocketHandler {
+
+    private static final Map<String, Set<WebSocketSession>> rooms = new ConcurrentHashMap<>();
+
+    private static final String ROOM_NUM_KEY = "roomNum";
+    private static final String SENDER_KEY = "senderId";
+    private static final String RECEIVER_KEY = "receiverId";
+
+    private final ChatMessageService chatMessageService;
+    private final ChatRoomService chatRoomService;
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        URI uri = session.getUri();
+        if (uri != null) {
+            Map<String, String> parameters = parseQueryParams(uri.getQuery());
+            checkChatRoom(parameters);
+            rooms.computeIfAbsent(parameters.get(ROOM_NUM_KEY), k -> new HashSet<>()).add(session);
+        } else {
+            log.warn("채팅방 번호가 존재하지 않는 세션입니다: 세션 ID: {}", session.getId());
+            session.close();
+        }
+    }
+
+    private void checkChatRoom(Map<String, String> parameters) {
+        String roomNum = parameters.get(ROOM_NUM_KEY);
+        Long senderId = Long.parseLong(parameters.get(SENDER_KEY));
+        Long receiverId = Long.parseLong(parameters.get(RECEIVER_KEY));
+        chatRoomService.validateChatRoom(roomNum, senderId, receiverId);
+
+        log.debug("WebSocket 연결 - roomNum: {}, senderId: {}, receiverId: {}", roomNum, senderId, receiverId);
+    }
+
+    private Map<String, String> parseQueryParams(String query) {
+        Map<String, String> paramMap = new HashMap<>();
+        if (query != null) {
+            String[] params = query.split("&");
+            for (String param : params) {
+                String[] keyValue = param.split("=");
+                if (keyValue.length == 2) {
+                    paramMap.put(keyValue[0], keyValue[1]);
+                }
+            }
+        }
+        return paramMap;
+    }
+
+    @Override
+    public void handleTransportError(WebSocketSession session, Throwable exception) throws Exception {
+        log.error("session transport exception, session id={}, error={}", session.getId(), exception.getMessage());
+        removeSessionFromRoom(session);
+        session.close();
+        logRoomSize();
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
+        log.debug("웹 소켓 종료 -> sessionId: {}", session.getId());
+        removeSessionFromRoom(session);
+        session.close();
+        logRoomSize();
+    }
+
+    @Override
+    protected void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        log.debug("웹 소켓 메시지 전송 -> sessionId: {}", session.getId());
+        ChatMessageRequestDto chatMessageRequestDto = readAndSaveMessage(message.getPayload());
+        sendMessage(session, message, chatMessageRequestDto.getRoomNum());
+    }
+    
+    private ChatMessageRequestDto readAndSaveMessage(String message) {
+        ChatMessageRequestDto chatMessageRequestDto = null;
+        try {
+            ObjectMapper objectMapper = new ObjectMapper();
+            chatMessageRequestDto = objectMapper.readValue(message, ChatMessageRequestDto.class);
+        } catch (Exception e) {
+            log.error("Object Mapper Binding Error!, message: {}", message);
+        }
+        chatMessageService.save(chatMessageRequestDto);
+
+        return chatMessageRequestDto;
+    }
+    
+    private void sendMessage(WebSocketSession session, TextMessage message, String roomNum) {
+        Set<WebSocketSession> sessions = rooms.get(roomNum);
+        sessions.forEach(s -> {
+            if (!s.getId().equals(session.getId())) {
+                try {
+                    s.sendMessage(message);
+                } catch (IOException e) {
+                    log.error("Send Message Failed! roomNum: {}, session: {}", roomNum, session.getId());
+                    throw new RuntimeException("Send Message Failed!");
+                }
+            }
+        });
+    }
+
+    private void removeSessionFromRoom(WebSocketSession session) {
+        rooms.forEach((roomNum, sessions) -> {
+            if (sessions.contains(session)) {
+                sessions.remove(session);
+                if (sessions.isEmpty()) {
+                    rooms.remove(roomNum);
+                }
+            }
+        });
+    }
+
+    private void logRoomSize() {
+        log.debug("남은 채팅방 개수: {}", rooms.size());
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/ChatRoomNotFoundException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/ChatRoomNotFoundException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CHAT_ROOM_NOT_FOUND;
+
+import org.springframework.http.HttpStatus;
+
+public class ChatRoomNotFoundException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+    @Override
+    public String getMessage() {
+        return CHAT_ROOM_NOT_FOUND.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/NotMemberOfChatRoomException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/NotMemberOfChatRoomException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.NOT_MEMBER_OF_CHAT_ROOM;
+
+import org.springframework.http.HttpStatus;
+
+public class NotMemberOfChatRoomException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+
+    @Override
+    public String getMessage() {
+        return NOT_MEMBER_OF_CHAT_ROOM.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/UserNotOwnerOfChatRoomException.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/exception/UserNotOwnerOfChatRoomException.java
@@ -1,0 +1,18 @@
+package com.carrot.carrotmarketclonecoding.common.exception;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FORBIDDEN;
+
+import org.springframework.http.HttpStatus;
+
+public class UserNotOwnerOfChatRoomException extends CustomException {
+
+    @Override
+    public HttpStatus getStatus() {
+        return HttpStatus.FORBIDDEN;
+    }
+
+    @Override
+    public String getMessage() {
+        return FORBIDDEN.getMessage();
+    }
+}

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/FailedMessage.java
@@ -34,6 +34,9 @@ public enum FailedMessage {
     ALREADY_READ_NOTIFICATION("이미 읽은 알림입니다!"),
 
     KEYWORD_OVER_LIMIT("키워드개수는 30개까지만 저장할 수 있습니다!"),
-    KEYWORD_NOT_FOUND("존재하지 않는 키워드입니다!");
+    KEYWORD_NOT_FOUND("존재하지 않는 키워드입니다!"),
+
+    CHAT_ROOM_NOT_FOUND("존재하지 않는 채팅방입니다!"),
+    NOT_MEMBER_OF_CHAT_ROOM("채팅방의 사용자가 아닙니다!");
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/common/response/SuccessMessage.java
@@ -42,7 +42,12 @@ public enum SuccessMessage {
     ADD_KEYWORD_SUCCESS("키워드 추가에 성공하였습니다!"),
     EDIT_KEYWORD_SUCCESS("키워드 편집에 성공하였습니다!"),
     GET_KEYWORDS_SUCCESS("사용자의 키워드 목록 조회에 성공하였습니다!"),
-    DELETE_KEYWORDS_SUCCESS("키워드 삭제에 성공하였습니다!");
+    DELETE_KEYWORDS_SUCCESS("키워드 삭제에 성공하였습니다!"),
+
+    CREATE_CHAT_ROOM_SUCCESS("채팅방 개설에 성공하였습니다!"),
+    GET_CHAT_ROOMS_SUCCESS("채팅방 목록 조회에 성공하였습니다!"),
+    DELETE_CHAT_ROOM_SUCCESS("채팅방 삭제에 성공하였습니다!"),
+    GET_CHAT_MESSAGES_SUCCESS("채팅 내역 조회에 성공하였습니다!");
 
     private final String message;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/config/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
                 }));
 
         http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/callback", "/hc", "/env", "/docs/**").permitAll()
+                .requestMatchers("/callback", "/hc", "/env", "/docs/**", "/test", "/chat/**").permitAll()
                 .requestMatchers("/**").hasRole("USER")
                 .anyRequest().permitAll()
         );

--- a/src/main/resources/application-blue.yml
+++ b/src/main/resources/application-blue.yml
@@ -14,6 +14,13 @@ spring:
       host: ENC(PgnZGrO2VsW7JQAPvnYD7spp5X0nxFWX)
       port: 6379
 
+    mongodb:
+      host: ENC(t4iCM1Oj6H6Rm4+XHUXiX/uzN22MhEl8)
+      port: 27017
+      username: ENC(CytuGEb222nsgbOgSGEoFV2/5+LBuSf7G2OJ9q25WdA=)
+      password: ENC(1lHrDMhc9mu5YWp/Zh5IwjmlFDTmp2J1)
+      database: ENC(qhxuCtJrM96e5tAyBnsHfWwUqr6hGx+i)
+
   jpa:
     show-sql: false
 
@@ -23,3 +30,6 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: blue_server
+
+websocket:
+  origin: ENC(kVsxrVJ0hlwQ2+pf/M8j6adRNV/B8G2JmH6U6qXq58g=)

--- a/src/main/resources/application-green.yml
+++ b/src/main/resources/application-green.yml
@@ -14,6 +14,13 @@ spring:
       host: ENC(PgnZGrO2VsW7JQAPvnYD7spp5X0nxFWX)
       port: 6379
 
+    mongodb:
+      host: ENC(t4iCM1Oj6H6Rm4+XHUXiX/uzN22MhEl8)
+      port: 27017
+      username: ENC(CytuGEb222nsgbOgSGEoFV2/5+LBuSf7G2OJ9q25WdA=)
+      password: ENC(1lHrDMhc9mu5YWp/Zh5IwjmlFDTmp2J1)
+      database: ENC(qhxuCtJrM96e5tAyBnsHfWwUqr6hGx+i)
+
   jpa:
     show-sql: false
 
@@ -23,3 +30,6 @@ server:
   serverAddress: ENC(dXcnoqAIp/O+aKQGMpLwNJ66ajoubJLH)
 
 serverName: green_server
+
+websocket:
+  origin: ENC(kVsxrVJ0hlwQ2+pf/M8j6adRNV/B8G2JmH6U6qXq58g=)

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -14,6 +14,13 @@ spring:
       host: 127.0.0.1
       port: 6379
 
+    mongodb:
+      host: localhost
+      port: 27017
+      username: ENC(GsCHiWIS/SjA7HliN3PtovpxB3yKKszJ)
+      password: ENC(iUd5g5W+lE5rQO7uhUbQFkjvH+P5RUsN)
+      database: ENC(qffKQ59Gd3EuH3G+7puCY/1Oubdbdb5F)
+
   jpa:
     show-sql: true
     properties:
@@ -31,3 +38,6 @@ serverName: localhost
 logging:
   level:
     com.carrot.carrotmarketclonecoding: DEBUG
+
+websocket:
+  origin: http://localhost:3000

--- a/src/main/resources/db/migration/V7__create_table_chat_room.sql
+++ b/src/main/resources/db/migration/V7__create_table_chat_room.sql
@@ -1,0 +1,11 @@
+CREATE TABLE `chat_room`
+(
+    `id`          BIGINT NOT NULL PRIMARY KEY AUTO_INCREMENT,
+    `room_num`     VARCHAR(255),
+    `sender_id`      BIGINT,
+    `receiver_id`    BIGINT,
+    `create_date` DATETIME,
+    `update_date` DATETIME,
+    FOREIGN KEY (`receiver_id`) REFERENCES `members`(`id`),
+    FOREIGN KEY (`sender_id`) REFERENCES `members`(`id`)
+);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/MongoTestContainerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/MongoTestContainerTest.java
@@ -1,0 +1,24 @@
+package com.carrot.carrotmarketclonecoding;
+
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
+
+public abstract class MongoTestContainerTest {
+    static final String MONGODB_IMAGE = "mongo:8.0.3";
+    static final int MONGODB_PORT = 27017;
+    static final GenericContainer MONGO_CONTAINER;
+
+    static {
+        MONGO_CONTAINER = new GenericContainer<>(MONGODB_IMAGE)
+                .withExposedPorts(MONGODB_PORT)
+                .withReuse(true);
+        MONGO_CONTAINER.start();
+    }
+
+    @DynamicPropertySource
+    public static void overrideProps(DynamicPropertyRegistry registry){
+        registry.add("spring.data.mongodb.host", MONGO_CONTAINER::getHost);
+        registry.add("spring.data.mongodb.port", () -> "" + MONGO_CONTAINER.getMappedPort(MONGODB_PORT));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatControllerTest.java
@@ -1,0 +1,285 @@
+package com.carrot.carrotmarketclonecoding.chat.controller;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.*;
+import static com.carrot.carrotmarketclonecoding.common.response.SuccessMessage.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.carrot.carrotmarketclonecoding.auth.config.WithCustomMockUser;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.helper.ChatDtoFactory;
+import com.carrot.carrotmarketclonecoding.chat.helper.ChatTestHelper;
+import com.carrot.carrotmarketclonecoding.chat.service.impl.ChatMessageServiceImpl;
+import com.carrot.carrotmarketclonecoding.chat.service.impl.ChatRoomServiceImpl;
+import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.common.exception.UserNotOwnerOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.util.RestDocsTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+@Import(value = {
+        ChatDtoFactory.class
+})
+@WithCustomMockUser
+@WebMvcTest(controllers = {ChatController.class})
+class ChatControllerTest extends RestDocsTestUtil {
+
+    private ChatTestHelper testHelper;
+
+    @Autowired
+    private ChatDtoFactory dtoFactory;
+
+    @MockBean
+    private ChatRoomServiceImpl chatRoomService;
+
+    @MockBean
+    private ChatMessageServiceImpl chatMessageService;
+
+    @BeforeEach
+    void setUp() {
+        this.testHelper = new ChatTestHelper(mvc, restDocs);
+    }
+
+    private ChatRoomCreateRequestDto request = ChatRoomCreateRequestDto.builder()
+            .senderId(1L) // TODO remove senderId Field
+            .receiverId(2L)
+            .build();
+
+    @Nested
+    @DisplayName("채팅방 생성 컨트롤러 테스트")
+    class CreateChatRoomTests {
+
+        @Test
+        @DisplayName("채팅방 생성 API 요청 성공")
+        void createChatRoomTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isCreated())
+                    .status(201)
+                    .result(true)
+                    .message(CREATE_CHAT_ROOM_SUCCESS.getMessage())
+                    .build();
+
+            // when
+            when(chatRoomService.create(anyLong(), any(ChatRoomCreateRequestDto.class))).thenReturn("test room");
+
+            // then
+            testHelper.assertCreateChatRoom(request, resultFields, "test room");
+        }
+
+        @Test
+        @DisplayName("채팅방 생성 API 요청시 전송자/수신자 데이터가 없을 경우 실패")
+        void createChatRoom_SenderOrReceiverNotFoundTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
+
+            // when
+            doThrow(MemberNotFoundException.class).when(chatRoomService).create(anyLong(), any(ChatRoomCreateRequestDto.class));
+
+            // then
+            testHelper.assertCreateChatRoomFail(request, resultFields);
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 목록 조회 컨트롤러 테스트")
+    class GetChatRoomsTests {
+
+        @Test
+        @DisplayName("채팅방 목록 조회 API 요청 성공")
+        void getChatRoomsTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(GET_CHAT_ROOMS_SUCCESS.getMessage())
+                    .build();
+
+            List<ChatRoomResponseDto> response = dtoFactory.createChatRoomResponseDtos();
+
+            // when
+            when(chatRoomService.getChatRooms(anyLong())).thenReturn(response);
+
+            // then
+            testHelper.assertGetChatRooms(resultFields);
+        }
+
+        @Test
+        @DisplayName("채팅방 목록 조회 시 사용자가 존재하지 않을 경우 실패")
+        void getChatRooms_MemberNotFoundTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
+
+            // when
+            doThrow(MemberNotFoundException.class).when(chatRoomService).getChatRooms(anyLong());
+
+            // then
+            testHelper.assertGetChatRoomsFail(resultFields);
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅내역 조회 컨트롤러 테스트")
+    class GetChatMessagesTests {
+
+        @Test
+        @DisplayName("채팅방의 채팅내역 조회 API 요청 성공")
+        void getChatMessagesTest() throws Exception {
+            // given
+            List<ChatMessageResponseDto> chatMessages = dtoFactory.createChatMessageResponseDtos();
+
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(GET_CHAT_MESSAGES_SUCCESS.getMessage())
+                    .build();
+
+            // when
+            when(chatMessageService.getChatMessages(anyLong(), anyLong())).thenReturn(chatMessages);
+
+            // then
+            testHelper.assertGetChatMessagesSuccess(resultFields, chatMessages);
+        }
+
+        @Test
+        @DisplayName("채팅내역을 조회할 채팅방이 존재하지 않음")
+        void getChatMessages_ChatRoomNotFoundTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isBadRequest())
+                    .status(400)
+                    .result(false)
+                    .message(CHAT_ROOM_NOT_FOUND.getMessage())
+                    .build();
+
+            // when
+            doThrow(ChatRoomNotFoundException.class).when(chatMessageService).getChatMessages(anyLong(), anyLong());
+
+            // then
+            testHelper.assertGetChatMessagesFail(resultFields);
+        }
+
+        @Test
+        @DisplayName("채팅내역 조회시 사용자의 채팅방이 아님")
+        void getChatMessages_NotMemberOfChatRoomTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isForbidden())
+                    .status(403)
+                    .result(false)
+                    .message(NOT_MEMBER_OF_CHAT_ROOM.getMessage())
+                    .build();
+
+            // when
+            doThrow(NotMemberOfChatRoomException.class).when(chatMessageService).getChatMessages(anyLong(), anyLong());
+
+            // then
+            testHelper.assertGetChatMessagesFail(resultFields);
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방 삭제 컨트롤러 테스트")
+    class DeleteChatRoomTests {
+
+        @Test
+        @DisplayName("채팅방 삭제 API 요청 성공")
+        void deleteChatRoomTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isOk())
+                    .status(200)
+                    .result(true)
+                    .message(DELETE_CHAT_ROOM_SUCCESS.getMessage())
+                    .build();
+
+            // when
+            doNothing().when(chatRoomService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteChatRoom(resultFields);
+        }
+
+        @Test
+        @DisplayName("삭제 요청한 채팅방이 사용자의 채팅방이 아닌 경우 실패")
+        void deleteChatRoom_UserIsNotOwnerTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isForbidden())
+                    .status(403)
+                    .result(false)
+                    .message(FORBIDDEN.getMessage())
+                    .build();
+
+            // when
+            doThrow(UserNotOwnerOfChatRoomException.class).when(chatRoomService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteChatRoom(resultFields);
+        }
+
+        @Test
+        @DisplayName("채팅방 삭제 요청시 사용자가 존재하지 않을 경우 실패")
+        void deleteChatRoom_MemberNotFoundTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isUnauthorized())
+                    .status(401)
+                    .result(false)
+                    .message(MEMBER_NOT_FOUND.getMessage())
+                    .build();
+
+            // when
+            doThrow(MemberNotFoundException.class).when(chatRoomService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteChatRoom(resultFields);
+        }
+
+        @Test
+        @DisplayName("삭제 요청한 채팅방이 존재하지 않을 경우 실패")
+        void deleteChatRoom_ChatRoomNotFoundTest() throws Exception {
+            // given
+            ResultFields resultFields = ResultFields.builder()
+                    .resultMatcher(status().isBadRequest())
+                    .status(400)
+                    .result(false)
+                    .message(CHAT_ROOM_NOT_FOUND.getMessage())
+                    .build();
+
+            // when
+            doThrow(ChatRoomNotFoundException.class).when(chatRoomService).delete(anyLong(), anyLong());
+
+            // then
+            testHelper.assertDeleteChatRoom(resultFields);
+        }
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatDtoFactory.java
@@ -1,0 +1,54 @@
+package com.carrot.carrotmarketclonecoding.chat.helper;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.boot.test.context.TestComponent;
+
+@TestComponent
+public class ChatDtoFactory {
+
+    public List<ChatRoomResponseDto> createChatRoomResponseDtos() {
+        return Arrays.asList(
+                ChatRoomResponseDto.builder()
+                        .id(1L)
+                        .roomNum("room1")
+                        .createDate(LocalDateTime.now())
+                        .build(),
+                ChatRoomResponseDto.builder()
+                        .id(2L)
+                        .roomNum("room2")
+                        .createDate(LocalDateTime.now())
+                        .build(),
+                ChatRoomResponseDto.builder()
+                        .id(3L)
+                        .roomNum("room3")
+                        .createDate(LocalDateTime.now())
+                        .build()
+        );
+    }
+
+    public List<ChatMessageResponseDto> createChatMessageResponseDtos() {
+        return Arrays.asList(
+                ChatMessageResponseDto.builder()
+                        .id("6736b9de2fe0d671812deafc")
+                        .senderId(3948203L)
+                        .receiverId(2394840L)
+                        .roomNum(UUID.randomUUID().toString())
+                        .message("test message content")
+                        .createDate(LocalDateTime.now())
+                        .build(),
+                ChatMessageResponseDto.builder()
+                        .id("6736b87082a20d63569446cb")
+                        .senderId(2394840L)
+                        .receiverId(3948203L)
+                        .roomNum(UUID.randomUUID().toString())
+                        .message("test message content")
+                        .createDate(LocalDateTime.now())
+                        .build()
+        );
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRequestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRequestHelper.java
@@ -1,0 +1,40 @@
+package com.carrot.carrotmarketclonecoding.chat.helper;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.util.ControllerRequestUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+@RequiredArgsConstructor
+public class ChatRequestHelper extends ControllerRequestUtil {
+
+    private final MockMvc mvc;
+
+    private static final String CHAT_URL = "/chat/room";
+
+    public ResultActions requestCreateChatRoom(ChatRoomCreateRequestDto request) throws Exception {
+        return mvc.perform(
+                requestWithCsrfAndSetContentType(post(CHAT_URL), MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(request))
+        );
+    }
+
+    public ResultActions requestGetChatRooms() throws Exception {
+        return mvc.perform(get(CHAT_URL));
+    }
+
+    public ResultActions requestGetChatMessages() throws Exception {
+        return mvc.perform(get(CHAT_URL + "/{id}", 1L));
+    }
+
+    public ResultActions requestDeleteChatRoom() throws Exception {
+        return mvc.perform(requestWithCsrf(delete(CHAT_URL + "/{id}", 1L)));
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRestDocsHelper.java
@@ -1,0 +1,101 @@
+package com.carrot.carrotmarketclonecoding.chat.helper;
+
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+
+import com.carrot.carrotmarketclonecoding.util.RestDocsHelper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.test.web.servlet.ResultHandler;
+
+@RequiredArgsConstructor
+public class ChatRestDocsHelper extends RestDocsHelper {
+
+    private final RestDocumentationResultHandler restDocs;
+
+    public ResultHandler createCreateChatRoomDocument() {
+        return restDocs.document(
+                requestFields(
+                        fieldWithPath("receiverId").description("수신자 아이디"),
+                        fieldWithPath("senderId").description("송신자 아이디")    // TODO remove fieldwithpath
+                ),
+                responseFields(
+                        addFieldsWithCommonFieldsDescriptors(getCreateChatRoomFieldDescriptors())
+                )
+        );
+    }
+
+    private FieldDescriptor[] getCreateChatRoomFieldDescriptors() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data").description("채팅방번호")
+        };
+    }
+
+    public ResultHandler createGetChatRoomsDocument() {
+        return restDocs.document(
+                responseFields(addFieldsWithCommonFieldsDescriptors(getChatRoomsFieldDescriptors()))
+        );
+    }
+
+    private FieldDescriptor[] getChatRoomsFieldDescriptors() {
+        return new FieldDescriptor[]{
+                fieldWithPath("data[].id").description("채팅방 아이디"),
+                fieldWithPath("data[].roomNum").description("채팅방 번호"),
+                fieldWithPath("data[].createDate").description("채팅방 개설시간")
+        };
+    }
+
+    public ResultHandler createGetChatMessagesDocument() {
+        return restDocs.document(
+                pathParameters(
+                        parameterWithName("id").description("채팅방 아이디")
+                ),
+                responseFields(
+                        addFieldsWithCommonFieldsDescriptors(
+                                getChatMessageFieldDescriptors()
+                        )
+                )
+        );
+    }
+
+    private FieldDescriptor[] getChatMessageFieldDescriptors() {
+        return new FieldDescriptor[] {
+                fieldWithPath("data[].id").description("채팅메시지 아이디"),
+                fieldWithPath("data[].roomNum").description("채팅방 번호"),
+                fieldWithPath("data[].senderId").description("채팅메시지 송신자 아이디"),
+                fieldWithPath("data[].receiverId").description("채팅메시지 수신자 아이디"),
+                fieldWithPath("data[].message").description("채팅메시지 내용"),
+                fieldWithPath("data[].createDate").description("채팅메시지 생성일"),
+        };
+    }
+
+    public ResultHandler createGetChatMessagesFailDocument() {
+        return restDocs.document(
+                pathParameters(
+                        parameterWithName("id").description("채팅방 아이디")
+                ),
+                responseFields(
+                        createResponseResultDescriptor()
+                )
+        );
+    }
+
+    public ResultHandler createDeleteChatRoomDocument() {
+        return restDocs.document(
+                pathParameters(
+                        parameterWithName("id").description("채팅방 아이디")
+                ),
+                responseFields(
+                        createResponseResultDescriptor()
+                )
+        );
+    }
+
+    public ResultHandler createResponseResultDocument() {
+        return createResponseResultDocument(restDocs);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatTestHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatTestHelper.java
@@ -1,0 +1,65 @@
+package com.carrot.carrotmarketclonecoding.chat.helper;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.util.ControllerTestUtil;
+import com.carrot.carrotmarketclonecoding.util.ResultFields;
+import java.util.List;
+import org.springframework.restdocs.mockmvc.RestDocumentationResultHandler;
+import org.springframework.test.web.servlet.MockMvc;
+
+public class ChatTestHelper extends ControllerTestUtil {
+
+    private final ChatRequestHelper requestHelper;
+    private final ChatRestDocsHelper restDocsHelper;
+
+    public ChatTestHelper(MockMvc mvc, RestDocumentationResultHandler restDocs) {
+        this.requestHelper = new ChatRequestHelper(mvc);
+        this.restDocsHelper = new ChatRestDocsHelper(restDocs);
+    }
+
+    public void assertCreateChatRoom(ChatRoomCreateRequestDto request, ResultFields resultFields, String roomNum) throws Exception {
+        assertResponseResult(requestHelper.requestCreateChatRoom(request), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(roomNum)))
+                .andDo(restDocsHelper.createCreateChatRoomDocument());
+    }
+
+    public void assertCreateChatRoomFail(ChatRoomCreateRequestDto request, ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestCreateChatRoom(request), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocsHelper.createResponseResultDocument());
+    }
+
+    public void assertGetChatRooms(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetChatRooms(), resultFields)
+                .andExpect(jsonPath("$.data.size()", equalTo(3)))
+                .andDo(restDocsHelper.createGetChatRoomsDocument());
+    }
+
+    public void assertGetChatRoomsFail(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetChatRooms(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocsHelper.createResponseResultDocument());
+    }
+
+    public void assertGetChatMessagesSuccess(ResultFields resultFields, List<ChatMessageResponseDto> chatMessages) throws Exception {
+        assertResponseResult(requestHelper.requestGetChatMessages(), resultFields)
+                .andExpect(jsonPath("$.data.size()", equalTo(chatMessages.size())))
+                .andDo(restDocsHelper.createGetChatMessagesDocument());
+    }
+
+    public void assertGetChatMessagesFail(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestGetChatMessages(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocsHelper.createGetChatMessagesFailDocument());
+    }
+
+    public void assertDeleteChatRoom(ResultFields resultFields) throws Exception {
+        assertResponseResult(requestHelper.requestDeleteChatRoom(), resultFields)
+                .andExpect(jsonPath("$.data", equalTo(null)))
+                .andDo(restDocsHelper.createDeleteChatRoomDocument());
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatMessageRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,69 @@
+package com.carrot.carrotmarketclonecoding.chat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrot.carrotmarketclonecoding.MongoTestContainerTest;
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatMessage;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class ChatMessageRepositoryTest extends MongoTestContainerTest {
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Test
+    void deleteAllByRoomNumTest() {
+        // given
+        String roomNum = "test room";
+        ChatMessage chatMessage = ChatMessage.builder()
+                .senderId(1111L)
+                .receiverId(2222L)
+                .roomNum(roomNum)
+                .message("test message")
+                .createDate(LocalDateTime.now())
+                .build();
+        chatMessageRepository.save(chatMessage);
+
+        // when
+        chatMessageRepository.deleteAllByRoomNum(roomNum);
+
+        // then
+        List<ChatMessage> result = chatMessageRepository.findAll();
+        assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
+    void findAllByRoomNumTest() {
+        // given
+        String roomNum = "test room";
+        ChatMessage chatMessage1 = ChatMessage.builder()
+                .senderId(1111L)
+                .receiverId(2222L)
+                .roomNum(roomNum)
+                .message("test message")
+                .createDate(LocalDateTime.now().minusDays(1))
+                .build();
+        ChatMessage chatMessage2 = ChatMessage.builder()
+                .senderId(1111L)
+                .receiverId(2222L)
+                .roomNum(roomNum)
+                .message("test message2")
+                .createDate(LocalDateTime.now())
+                .build();
+        chatMessageRepository.save(chatMessage1);
+        chatMessageRepository.save(chatMessage2);
+
+        // when
+        List<ChatMessage> result = chatMessageRepository.findAllByRoomNumOrderByCreateDateDesc(roomNum);
+
+        // then
+        assertThat(result.get(0).getMessage()).isEqualTo("test message2");
+        assertThat(result.get(1).getMessage()).isEqualTo("test message");
+        assertThat(result.size()).isEqualTo(2);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepositoryTest.java
@@ -1,0 +1,84 @@
+package com.carrot.carrotmarketclonecoding.chat.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class ChatRoomRepositoryTest {
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Test
+    void findAllBySenderTest() {
+        // given
+        Member sender = Member.builder()
+                .authId(1111L)
+                .build();
+        ChatRoom chatRoom1 = ChatRoom.builder()
+                .sender(sender)
+                .build();
+        ChatRoom chatRoom2 = ChatRoom.builder()
+                .sender(sender)
+                .build();
+        memberRepository.save(sender);
+        chatRoomRepository.save(chatRoom1);
+        chatRoomRepository.save(chatRoom2);
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllBySender(sender);
+
+        // then
+        assertThat(chatRooms.size()).isEqualTo(2);
+    }
+
+    @Test
+    void findAllByReceiverTest() {
+        // given
+        Member receiver = Member.builder()
+                .authId(1111L)
+                .build();
+        ChatRoom chatRoom1 = ChatRoom.builder()
+                .receiver(receiver)
+                .build();
+        ChatRoom chatRoom2 = ChatRoom.builder()
+                .receiver(receiver)
+                .build();
+        memberRepository.save(receiver);
+        chatRoomRepository.save(chatRoom1);
+        chatRoomRepository.save(chatRoom2);
+
+        // when
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllByReceiver(receiver);
+
+        // then
+        assertThat(chatRooms.size()).isEqualTo(2);
+    }
+
+    @Test
+    void findByRoomNumTest() {
+        // given
+        String roomNum = "test room";
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomNum(roomNum)
+                .build();
+        chatRoomRepository.save(chatRoom);
+
+        // when
+        Optional<ChatRoom> result = chatRoomRepository.findByRoomNum(roomNum);
+
+        // then
+        assertThat(result.isPresent()).isEqualTo(true);
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatMessageServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatMessageServiceTest.java
@@ -1,0 +1,179 @@
+package com.carrot.carrotmarketclonecoding.chat.service.impl;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CHAT_ROOM_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.NOT_MEMBER_OF_CHAT_ROOM;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatMessage;
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatMessageRepository;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
+import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatMessageServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ChatMessageRepository chatMessageRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @InjectMocks
+    private ChatMessageServiceImpl chatMessageService;
+
+    @Nested
+    @DisplayName("채팅메시지 저장 서비스 테스트")
+    class SaveChatMessageTests {
+
+        @Test
+        @DisplayName("채팅메시지 저장 성공")
+        void saveChatMessageTest() {
+            // given
+            Member mockSender = Member.builder().authId(1L).build();
+            when(memberRepository.findByAuthId(1L)).thenReturn(Optional.of(mockSender));
+
+            Member mockReceiver = Member.builder().authId(2L).build();
+            when(memberRepository.findByAuthId(2L)).thenReturn(Optional.of(mockReceiver));
+
+            // when
+            ChatMessageRequestDto request = ChatMessageRequestDto.builder()
+                    .senderId(1L)
+                    .receiverId(2L)
+                    .message("test message")
+                    .roomNum("test room")
+                    .build();
+            chatMessageService.save(request);
+
+            // then
+            ArgumentCaptor<ChatMessage> chatMessageArgumentCaptor = ArgumentCaptor.forClass(ChatMessage.class);
+            verify(chatMessageRepository, times(1)).save(chatMessageArgumentCaptor.capture());
+            ChatMessage chatMessage = chatMessageArgumentCaptor.getValue();
+            assertThat(chatMessage.getSenderId()).isEqualTo(request.getSenderId());
+            assertThat(chatMessage.getReceiverId()).isEqualTo(request.getReceiverId());
+            assertThat(chatMessage.getMessage()).isEqualTo(request.getMessage());
+            assertThat(chatMessage.getRoomNum()).isEqualTo(request.getRoomNum());
+        }
+
+        @Test
+        @DisplayName("채팅메시지 저장시 사용자가 존재하지 않을 경우 예외 발생")
+        void saveChatMessageMemberNotFoundTest() {
+            // given
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatMessageService.save(mock(ChatMessageRequestDto.class)))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방의 채팅메시지 목록 조회 서비스 테스트")
+    class GetChatMessagesTests {
+
+        @Test
+        @DisplayName("채팅방의 채팅메시지 목록 조회 성공")
+        void getChatMessagesTest() {
+            // given
+            String roomNum = "test room";
+            ChatRoom mockChatRoom = ChatRoom.builder()
+                    .id(1L)
+                    .sender(Member.builder().authId(1111L).build())
+                    .receiver(Member.builder().authId(2222L).build())
+                    .roomNum(roomNum)
+                    .build();
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(mockChatRoom));
+
+            List<ChatMessage> chatMessages = Arrays.asList(
+                    ChatMessage.builder().build(),
+                    ChatMessage.builder().build(),
+                    ChatMessage.builder().build()
+            );
+            when(chatMessageRepository.findAllByRoomNumOrderByCreateDateDesc(anyString())).thenReturn(chatMessages);
+
+            // when
+            List<ChatMessageResponseDto> chatMessagesResponse = chatMessageService.getChatMessages(1111L, 1L);
+
+            // then
+            assertThat(chatMessagesResponse.size()).isEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("채팅메시지 목록 조회시 채팅방이 존재하지 않을 경우 예외 발생")
+        void getChatMessages_ChatRoomNotFound() {
+            // given
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatMessageService.getChatMessages(1111L, 1L))
+                    .isInstanceOf(ChatRoomNotFoundException.class)
+                    .hasMessage(CHAT_ROOM_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("채팅메시지 목록 조회시 사용자의 채팅방이 아닐 경우 예외 발생")
+        void getChatMessages_NotMemberOfChatRoom() {
+            // given
+            ChatRoom mockChatRoom = ChatRoom.builder()
+                    .id(1L)
+                    .sender(Member.builder().authId(1111L).build())
+                    .receiver(Member.builder().authId(2222L).build())
+                    .build();
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(mockChatRoom));
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatMessageService.getChatMessages(3333L, 1L))
+                    .isInstanceOf(NotMemberOfChatRoomException.class)
+                    .hasMessage(NOT_MEMBER_OF_CHAT_ROOM.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방의 모든 메세지 삭제 서비스 테스트")
+    class DeleteAllChatMessagesTests {
+
+        @Test
+        @DisplayName("채팅방의 모든 메세지 삭제 성공")
+        void deleteAllTest() {
+            // given
+            String roomNum = "test room";
+
+            // when
+            chatMessageService.deleteAll(roomNum);
+
+            // then
+            verify(chatMessageRepository, times(1)).deleteAllByRoomNum(roomNum);
+        }
+    }
+}

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceTest.java
@@ -1,0 +1,309 @@
+package com.carrot.carrotmarketclonecoding.chat.service.impl;
+
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.CHAT_ROOM_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.FORBIDDEN;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.MEMBER_NOT_FOUND;
+import static com.carrot.carrotmarketclonecoding.common.response.FailedMessage.NOT_MEMBER_OF_CHAT_ROOM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
+import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
+import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
+import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.common.exception.UserNotOwnerOfChatRoomException;
+import com.carrot.carrotmarketclonecoding.member.domain.Member;
+import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomServiceTest {
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ChatMessageServiceImpl chatMessageService;
+
+    @InjectMocks
+    private ChatRoomServiceImpl chatRoomService;
+
+    @Nested
+    @DisplayName("채팅방 생성 테스트")
+    class CreateChatRoomTests {
+
+        @Test
+        @DisplayName("채팅방 저장 후 채팅방 번호 반환 성공")
+        void createChatRoomTest() {
+            // given
+            Member mockSender = Member.builder().id(1L).authId(1L).build();
+            when(memberRepository.findByAuthId(1L)).thenReturn(Optional.of(mockSender));
+
+            Member mockReceiver = Member.builder().id(2L).authId(2L).build();
+            when(memberRepository.findByAuthId(2L)).thenReturn(Optional.of(mockReceiver));
+
+            // when
+            ChatRoomCreateRequestDto request = ChatRoomCreateRequestDto.builder()
+                    .receiverId(2L)
+                    .build();
+            String roomNum = chatRoomService.create(1L, request);
+
+            // then
+            assertThat(roomNum).isNotNull();
+
+            ArgumentCaptor<ChatRoom> chatRoomArgumentCaptor = ArgumentCaptor.forClass(ChatRoom.class);
+            verify(chatRoomRepository, times(1)).save(chatRoomArgumentCaptor.capture());
+
+            ChatRoom chatRoom = chatRoomArgumentCaptor.getValue();
+            assertThat(chatRoom.getSender().getAuthId()).isEqualTo(1L);
+            assertThat(chatRoom.getReceiver().getAuthId()).isEqualTo(2L);
+        }
+
+        @Test
+        @DisplayName("채팅방 생성시 송신자가 존재하지 않을 경우 MemberNotFoundException 발생")
+        void createChatRoomSenderNotFoundTest() {
+            // given
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            ChatRoomCreateRequestDto request = ChatRoomCreateRequestDto.builder()
+                    .receiverId(2L)
+                    .build();
+            assertThatThrownBy(() -> chatRoomService.create(1L, request))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("채팅방 생성시 수신자가 존재하지 않을 경우 MemberNotFoundException 발생")
+        void createChatRoomReceiverNotFoundTest() {
+            // given
+            Member mockSender = Member.builder().id(1L).build();
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockSender));
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            ChatRoomCreateRequestDto request = ChatRoomCreateRequestDto.builder()
+                    .receiverId(2L)
+                    .build();
+            assertThatThrownBy(() -> chatRoomService.create(1L, request))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자의 채팅방 목록 조회")
+    class GetChatRoomsTests {
+
+        @Test
+        @DisplayName("사용자의 채팅방 목록 조회 성공")
+        void getChatRoomsTest() {
+            // given
+            Member mockMember = Member.builder()
+                    .id(1L)
+                    .build();
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
+
+            List<ChatRoom> chatRooms1 = List.of(
+                    ChatRoom.builder().id(1L).build(),
+                    ChatRoom.builder().id(2L).build(),
+                    ChatRoom.builder().id(3L).build()
+            );
+            ReflectionTestUtils.setField(chatRooms1.get(0), "createDate", LocalDateTime.of(2024, 11, 1, 12, 0));
+            ReflectionTestUtils.setField(chatRooms1.get(1), "createDate", LocalDateTime.of(2024, 11, 2, 12, 0));
+            ReflectionTestUtils.setField(chatRooms1.get(2), "createDate", LocalDateTime.of(2024, 11, 3, 12, 0));
+            when(chatRoomRepository.findAllBySender(any(Member.class))).thenReturn(chatRooms1);
+
+            List<ChatRoom> chatRooms2 = List.of(
+                    ChatRoom.builder().id(4L).build(),
+                    ChatRoom.builder().id(5L).build(),
+                    ChatRoom.builder().id(6L).build()
+            );
+            ReflectionTestUtils.setField(chatRooms2.get(0), "createDate", LocalDateTime.of(2024, 11, 4, 12, 0));
+            ReflectionTestUtils.setField(chatRooms2.get(1), "createDate", LocalDateTime.of(2024, 11, 5, 12, 0));
+            ReflectionTestUtils.setField(chatRooms2.get(2), "createDate", LocalDateTime.of(2024, 11, 6, 12, 0));
+            when(chatRoomRepository.findAllByReceiver(any(Member.class))).thenReturn(chatRooms2);
+
+            // when
+            List<ChatRoomResponseDto> chatRoomDtos = chatRoomService.getChatRooms(1111L);
+
+            // then
+            assertThat(chatRoomDtos.size()).isEqualTo(6);
+        }
+
+        @Test
+        @DisplayName("사용자의 채팅방 목록 조회시 사용자가 존재하지 않을 경우 MemberNotFound 예외 발생")
+        void getCharRoomsMemberNotFoundTest() {
+            // given
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.getChatRooms(1111L))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자의 채팅방 삭제")
+    class DeleteChatRoomTests {
+
+        @Test
+        @DisplayName("사용자의 채팅방 삭제 성공")
+        void deleteChatRoomTest() {
+            // given
+            Member mockMember = Member.builder()
+                    .id(1L)
+                    .build();
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
+
+            ChatRoom mockChatRoom = ChatRoom.builder()
+                    .id(1L)
+                    .roomNum("test room")
+                    .sender(mockMember)
+                    .build();
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(mockChatRoom));
+
+            // when
+            chatRoomService.delete(1111L, 1L);
+
+            // then
+            verify(chatRoomRepository, times(1)).delete(mockChatRoom);
+            verify(chatMessageService, times(1)).deleteAll(mockChatRoom.getRoomNum());
+        }
+
+        @Test
+        @DisplayName("삭제하려는 채팅방이 사용자의 채팅방이 아닐경우 예외 발생")
+        void deleteChatRoomUserIsNotOwnerTest() {
+            // given
+            Member mockMember = Member.builder()
+                    .id(1L)
+                    .build();
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
+
+            ChatRoom mockChatRoom = ChatRoom.builder()
+                    .id(1L)
+                    .sender(Member.builder().id(2L).build())
+                    .build();
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.of(mockChatRoom));
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.delete(1111L, 1L))
+                    .isInstanceOf(UserNotOwnerOfChatRoomException.class)
+                    .hasMessage(FORBIDDEN.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제하려는 채팅방의 사용자가 존재하지 않을 경우 예외 발생")
+        void deleteChatRoomMemberNotFoundTest() {
+            // given
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.delete(1L, 1L))
+                    .isInstanceOf(MemberNotFoundException.class)
+                    .hasMessage(MEMBER_NOT_FOUND.getMessage());
+        }
+
+        @Test
+        @DisplayName("삭제하려는 채팅방이 존재하지 않을 경우 예외 발생")
+        void deleteChatRoomButChatRoomNotFoundTest() {
+            // given
+            Member mockMember = Member.builder().id(1L).build();
+            when(memberRepository.findByAuthId(anyLong())).thenReturn(Optional.of(mockMember));
+            when(chatRoomRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.delete(1L, 1L))
+                    .isInstanceOf(ChatRoomNotFoundException.class)
+                    .hasMessage(CHAT_ROOM_NOT_FOUND.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("채팅방의 사용자 확인 테스트")
+    class ValidateChatRoomTests {
+
+        @Test
+        @DisplayName("채팅방의 사용자, 수신자가 맞는지 확인 테스트")
+        void validateChatRoomOfSenderAndReceiverTest() {
+            // given
+            Member sender = Member.builder().id(1L).authId(1111L).build();
+            Member receiver = Member.builder().id(2L).authId(2222L).build();
+            ChatRoom chatRoom = ChatRoom.builder()
+                    .roomNum("test room")
+                    .sender(sender)
+                    .receiver(receiver)
+                    .build();
+
+            // when
+            when(chatRoomRepository.findByRoomNum(anyString())).thenReturn(Optional.of(chatRoom));
+
+            // then
+            chatRoomService.validateChatRoom("test room", 2222L, 1111L);
+        }
+
+        @Test
+        @DisplayName("채팅방의 송신자/수신자와 맞지 않을 경우 예외 발생")
+        void validateChatRoomOfSenderAndReceiver_NotMemberOfChatRoomTest() {
+            // given
+            Member sender = Member.builder().id(1L).authId(1111L).build();
+            Member receiver = Member.builder().id(2L).authId(2222L).build();
+            ChatRoom chatRoom = ChatRoom.builder()
+                    .roomNum("test room")
+                    .sender(sender)
+                    .receiver(receiver)
+                    .build();
+            when(chatRoomRepository.findByRoomNum(anyString())).thenReturn(Optional.of(chatRoom));
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.validateChatRoom("test room", 2222L, 3333L))
+                    .isInstanceOf(NotMemberOfChatRoomException.class)
+                    .hasMessage(NOT_MEMBER_OF_CHAT_ROOM.getMessage());
+        }
+
+        @Test
+        @DisplayName("채팅방이 존재하지 않을 경우 예외 발생")
+        void validateChatRoomOfSenderAndReceiver_ChatRoomNotFound() {
+            // given
+            when(chatRoomRepository.findByRoomNum(anyString())).thenReturn(Optional.empty());
+
+            // when
+            // then
+            assertThatThrownBy(() -> chatRoomService.validateChatRoom("test room", 1111L, 2222L))
+                    .isInstanceOf(ChatRoomNotFoundException.class)
+                    .hasMessage(CHAT_ROOM_NOT_FOUND.getMessage());
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -37,3 +37,6 @@ jwt:
   secret: ENC(AZSMHtQVuCDzJNRt1ln9wKpeKm13cB6U9zIp23MOjjyBNIOqa+X7lMeAo8ki+bmW)
   expiration_time: ENC(Lo7/s4mCESUiz0GI8/WYGA==)
   refresh_expiration_time: ENC(k/35hOfhQC6TeZV6bs7KwhQo3I844ujZ)
+
+websocket:
+  origin: http://localhost:3000


### PR DESCRIPTION
## PR 개요
기능 구현

## 내용(에러내용)
### 웹소켓 채팅 기능 구현
- WebSocket을 사용하여 양방향 통신으로 실시간 채팅 기능 구현
- 데이터베이스는 MongoDB를 사용

### 구현 API
- 채팅방 생성
- 선택한 채팅방의 이전 채팅 내역 조회
- 사용자의 채팅방 목록 조회
- 사용자의 채팅방 삭제 -> 채팅방에 속한 메시지 모두 삭제

### 채팅 과정
- 채팅 상대방의 아이디를 전송하여 채팅방 생성 및 채팅방 번호 요청 (ChatRoom 저장 - MySql) -> 서버에서 채팅방 번호 응답
- 채팅방번호를 이용하여 웹소켓 접속 -> 서버에서 채팅방 번호를 키로 하여 웹소켓 세션 저장
- 채팅메시지를 json 형식으로 전송 -> 서버에서 메시지를 파싱하여 저장(MongoDb) 및 채팅방번호를 키로 하는 웹소켓 세션중 상대방을 찾아 메시지 전송

resolved #148 

## 스크린샷

## 참고자료
