### PR TITLE
게시글 상세정보 조회시 채팅방 수 를 함께 리턴하도록 수정

### DIFF
--- a/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/board/dto/BoardResponseDto.java
@@ -43,7 +43,7 @@ public class BoardResponseDto {
         private int like;
         private int visit;
 
-        public static BoardDetailResponseDto createBoardDetail(Board board, int like) {
+        public static BoardDetailResponseDto createBoardDetail(Board board, int like, int chatRoomCnt) {
             return BoardDetailResponseDto.builder()
                     .id(board.getId())
                     .writer(board.getMember().getNickname())
@@ -60,6 +60,7 @@ public class BoardResponseDto {
                     .pictures(board.getBoardPictures().stream()
                             .map(PictureResponseDto::createPictureDetail)
                             .collect(Collectors.toList()))
+                    .chat(chatRoomCnt)
                     .like(like)
                     .visit(board.getVisit())
                     .build();

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatRoom.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/domain/ChatRoom.java
@@ -1,5 +1,6 @@
 package com.carrot.carrotmarketclonecoding.chat.domain;
 
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.common.BaseEntity;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import jakarta.persistence.Entity;
@@ -29,4 +30,7 @@ public class ChatRoom extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Member receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Board board;
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomRequestDto.java
@@ -11,6 +11,7 @@ public class ChatRoomRequestDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ChatRoomCreateRequestDto {
+        private Long boardId;
         private Long receiverId;
     }
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/dto/ChatRoomResponseDto.java
@@ -12,12 +12,14 @@ import lombok.*;
 @AllArgsConstructor
 public class ChatRoomResponseDto {
     private Long id;
+    private Long boardId;
     private String roomNum;
     private LocalDateTime createDate;
 
     public static ChatRoomResponseDto createChatRoomResponseDto(ChatRoom chatRoom) {
         return ChatRoomResponseDto.builder()
                 .id(chatRoom.getId())
+                .boardId(chatRoom.getBoard().getId())
                 .roomNum(chatRoom.getRoomNum())
                 .createDate(chatRoom.getCreateDate())
                 .build();

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepository.java
@@ -1,5 +1,6 @@
 package com.carrot.carrotmarketclonecoding.chat.repository;
 
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.util.List;
@@ -12,4 +13,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     List<ChatRoom> findAllByReceiver(Member receiver);
 
     Optional<ChatRoom> findByRoomNum(String roomNum);
+
+    List<ChatRoom> findByBoard(Board board);
 }

--- a/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceImpl.java
+++ b/src/main/java/com/carrot/carrotmarketclonecoding/chat/service/impl/ChatRoomServiceImpl.java
@@ -1,5 +1,7 @@
 package com.carrot.carrotmarketclonecoding.chat.service.impl;
 
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
+import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
 import com.carrot.carrotmarketclonecoding.chat.dto.ChatMessageRequestDto;
 import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomRequestDto.ChatRoomCreateRequestDto;
@@ -7,6 +9,7 @@ import com.carrot.carrotmarketclonecoding.chat.dto.ChatRoomResponseDto;
 import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
 import com.carrot.carrotmarketclonecoding.chat.service.ChatMessageService;
 import com.carrot.carrotmarketclonecoding.chat.service.ChatRoomService;
+import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.ChatRoomNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.MemberNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.NotMemberOfChatRoomException;
@@ -28,16 +31,19 @@ public class ChatRoomServiceImpl implements ChatRoomService {
 
     private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final BoardRepository boardRepository;
     private final ChatMessageService chatMessageService;
 
     @Override
     public String create(Long authId, ChatRoomCreateRequestDto createRequestDto) {
         Member sender = memberRepository.findByAuthId(authId).orElseThrow(MemberNotFoundException::new);
         Member receiver = memberRepository.findByAuthId(createRequestDto.getReceiverId()).orElseThrow(MemberNotFoundException::new);
+        Board board = boardRepository.findById(createRequestDto.getBoardId()).orElseThrow(BoardNotFoundException::new);
 
         String roomNum = UUID.randomUUID().toString();
         ChatRoom chatRoom = ChatRoom.builder()
                 .roomNum(roomNum)
+                .board(board)
                 .sender(sender)
                 .receiver(receiver)
                 .build();

--- a/src/main/resources/db/migration/V8__alter_table_chat_room.sql
+++ b/src/main/resources/db/migration/V8__alter_table_chat_room.sql
@@ -1,0 +1,5 @@
+ALTER TABLE chat_room
+    ADD COLUMN board_id BIGINT NOT NULL;
+
+ALTER TABLE chat_room
+    ADD CONSTRAINT FOREIGN KEY(board_id) REFERENCES boards(id);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/board/service/BoardServiceTest.java
@@ -25,6 +25,8 @@ import com.carrot.carrotmarketclonecoding.board.repository.BoardRepository;
 import com.carrot.carrotmarketclonecoding.category.repository.CategoryRepository;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardPictureService;
 import com.carrot.carrotmarketclonecoding.board.service.impl.BoardServiceImpl;
+import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
+import com.carrot.carrotmarketclonecoding.chat.repository.ChatRoomRepository;
 import com.carrot.carrotmarketclonecoding.common.exception.BoardNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.CategoryNotFoundException;
 import com.carrot.carrotmarketclonecoding.common.exception.FileUploadLimitException;
@@ -35,6 +37,7 @@ import com.carrot.carrotmarketclonecoding.common.response.PageResponseDto;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import com.carrot.carrotmarketclonecoding.member.repository.MemberRepository;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -72,6 +75,9 @@ class BoardServiceTest {
 
     @Mock
     private BoardLikeRepository boardLikeRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
 
     @Mock
     private VisitRedisService visitRedisService;
@@ -198,6 +204,12 @@ class BoardServiceTest {
             when(boardRepository.findById(anyLong())).thenReturn(Optional.of(mockBoard));
             when(boardLikeRepository.countByBoard(any())).thenReturn(10);
             when(visitRedisService.increaseVisit(anyString(), any(), any())).thenReturn(true);
+
+            List<ChatRoom> chatRooms = Arrays.asList(ChatRoom.builder()
+                    .receiver(mockMember)
+                    .board(mockBoard)
+                    .build());
+            when(chatRoomRepository.findByBoard(any(Board.class))).thenReturn(chatRooms);
 
             // when
             BoardDetailResponseDto result = boardService.getBoardDetail(boardId, request);

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatControllerTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/controller/ChatControllerTest.java
@@ -40,6 +40,7 @@ class ChatControllerTest extends ControllerTest {
     }
 
     private ChatRoomCreateRequestDto request = ChatRoomCreateRequestDto.builder()
+            .boardId(1L)
             .receiverId(2L)
             .build();
 

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatDtoFactory.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatDtoFactory.java
@@ -15,16 +15,19 @@ public class ChatDtoFactory {
         return Arrays.asList(
                 ChatRoomResponseDto.builder()
                         .id(1L)
+                        .boardId(1L)
                         .roomNum("room1")
                         .createDate(LocalDateTime.now())
                         .build(),
                 ChatRoomResponseDto.builder()
                         .id(2L)
+                        .boardId(2L)
                         .roomNum("room2")
                         .createDate(LocalDateTime.now())
                         .build(),
                 ChatRoomResponseDto.builder()
                         .id(3L)
+                        .boardId(3L)
                         .roomNum("room3")
                         .createDate(LocalDateTime.now())
                         .build()

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRestDocsHelper.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/helper/ChatRestDocsHelper.java
@@ -20,6 +20,7 @@ public class ChatRestDocsHelper extends RestDocsHelper {
     public ResultHandler createCreateChatRoomDocument() {
         return restDocs.document(
                 requestFields(
+                        fieldWithPath("boardId").description("게시글 아이디"),
                         fieldWithPath("receiverId").description("수신자 아이디")
                 ),
                 responseFields(
@@ -43,6 +44,7 @@ public class ChatRestDocsHelper extends RestDocsHelper {
     private FieldDescriptor[] getChatRoomsFieldDescriptors() {
         return new FieldDescriptor[]{
                 fieldWithPath("data[].id").description("채팅방 아이디"),
+                fieldWithPath("data[].boardId").description("게시글 아이디"),
                 fieldWithPath("data[].roomNum").description("채팅방 번호"),
                 fieldWithPath("data[].createDate").description("채팅방 개설시간")
         };

--- a/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepositoryTest.java
+++ b/src/test/java/com/carrot/carrotmarketclonecoding/chat/repository/ChatRoomRepositoryTest.java
@@ -3,6 +3,7 @@ package com.carrot.carrotmarketclonecoding.chat.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.carrot.carrotmarketclonecoding.RepositoryTest;
+import com.carrot.carrotmarketclonecoding.board.domain.Board;
 import com.carrot.carrotmarketclonecoding.chat.domain.ChatRoom;
 import com.carrot.carrotmarketclonecoding.member.domain.Member;
 import java.util.List;
@@ -71,5 +72,29 @@ class ChatRoomRepositoryTest extends RepositoryTest {
 
         // then
         assertThat(result.isPresent()).isEqualTo(true);
+    }
+
+    @Test
+    void findByBoardTest() {
+        // given
+        Board board = Board.builder().build();
+        boardRepository.save(board);
+
+        Member receiver = Member.builder().build();
+        memberRepository.save(receiver);
+
+        ChatRoom chatRoom = ChatRoom.builder()
+                .roomNum("test room")
+                .board(board)
+                .receiver(receiver)
+                .build();
+        chatRoomRepository.save(chatRoom);
+
+        // when
+        List<ChatRoom> result = chatRoomRepository.findByBoard(board);
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).getRoomNum()).isEqualTo("test room");
     }
 }


### PR DESCRIPTION
## PR 개요
기능 수정

## 내용
게시글 상세정보 조회시 채팅방 수 를 함께 리턴하도록 수정

## 관련 이슈
resolved #159 

## 스크린샷

## 참고자료
